### PR TITLE
Add missing entries for freifunk-muenchen.de and freifunk-muenchen.net

### DIFF
--- a/nginx/domains/ffmuc.net.conf
+++ b/nginx/domains/ffmuc.net.conf
@@ -29,7 +29,7 @@ server {
         www.ffmuc.bayern ffmuc.bayern 
         muenchen.freifunk.net
         www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
-	www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
+        www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
     
     # Force HTTPS connection. This rules is domain agnostic
     if ($scheme != "https") {
@@ -215,6 +215,6 @@ server {
         muenchen.freifunk.net
         wiki.ffmuc.net
         www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
-	www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
+        www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
     return 404; # managed by Certbot
 }

--- a/nginx/domains/ffmuc.net.conf
+++ b/nginx/domains/ffmuc.net.conf
@@ -28,7 +28,8 @@ server {
         www.freewifi.bayern freewifi.bayern 
         www.ffmuc.bayern ffmuc.bayern 
         muenchen.freifunk.net
-        freifunk-muenchen.de hp.freifunk-muenchen.de;
+        www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
+	www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
     
     # Force HTTPS connection. This rules is domain agnostic
     if ($scheme != "https") {
@@ -177,6 +178,30 @@ server {
         return 301 https://$host$request_uri;
     } # managed by Certbot
     
+    if ($host = freifunk-muenchen.de) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
+    if ($host = www.freifunk-muenchen.de) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
+    if ($host = hp.freifunk-muenchen.de) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
+    if ($host = freifunk-muenchen.net) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
+    if ($host = www.freifunk-muenchen.net) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
+    if ($host = hp.freifunk-muenchen.net) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+    
     if ( $host = wiki.ffmuc.net) {
        return 301 https://ffmuc.net/wiki/doku.php;
     }
@@ -189,6 +214,7 @@ server {
         www.ffmuc.bayern ffmuc.bayern 
         muenchen.freifunk.net
         wiki.ffmuc.net
-        freifunk-muenchen.de hp.freifunk-muenchen.de;
+        www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
+	www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net;
     return 404; # managed by Certbot
 }


### PR DESCRIPTION
freifunk-muenchen.de/net, combined with either http or https, and with "www" or "hp" hostnames show different strange results, either returning a 404 or redirect to firmware.ffmuc.net instead. This change serves the ffmuc homepage for all of the above combinations and redirects http to https. 

This change does not address the wrong DNS/Cloudflare configuration for freifunk-muenchen.de, and it does not take care of adding "www" and "hp" entries to the Cloudflare/LetsEncrypt SSL certificates.