### PR TITLE
Extend server_name to match requests with IP address only

### DIFF
--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -11,7 +11,7 @@ server {
     listen [::]:80;
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name _ firmware.ffmuc.net firmware.in.ffmuc.net;
+    server_name firmware.ffmuc.net firmware.in.ffmuc.net 5.1.66.255 [2001:678:e68:f000::] "";
 
     client_max_body_size 2048M;
 


### PR DESCRIPTION
Handle HTTP requests sent using the IP address as Host header, or without a Host header, as firmware requests. This is necessary in case DNS is not working on the nodes, to still be able to fetch updates.