### PR TITLE
Make firmware the default nginx server and remove IP addresses

### DIFF
--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -1,10 +1,10 @@
 
 server {
-    listen 80;
-    listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
-    server_name firmware.ffmuc.net firmware.in.ffmuc.net 5.1.66.255 [2001:678:e68:f000::] "";
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    listen 443 ssl http2 default_server;
+    listen [::]:443 ssl http2 default_server;
+    server_name firmware.ffmuc.net firmware.in.ffmuc.net "";
 
     client_max_body_size 2048M;
 


### PR DESCRIPTION
When moving to the Vienna datacenter, the IP addresses of the new location were added to the firmware nginx configuration, so that nodes can load firmware updates without working DNS. Instead firmware is now made the default server, so any unmatched hostname/ip address will be treated as the firmware site. This way it works as expected regardless of the location and does not need to be adapted, if an IP address is added or changed.