### PR TITLE
Increase metric_buffer_limit of telegraf to avoid dropped metrics

### DIFF
--- a/telegraf/files/telegraf.conf
+++ b/telegraf/files/telegraf.conf
@@ -6,7 +6,7 @@
   interval = "10s"
   round_interval = true
   metric_batch_size = 1000
-  metric_buffer_limit = 10000
+  metric_buffer_limit = 20000
   collection_jitter = "0s"
   flush_interval = "10s"
   flush_jitter = "0s"


### PR DESCRIPTION
Due to the high amount of metrics sent simultaneously by all systems at exactly :10, :20, :30,... the delay in processing/accepting them in influxdb may cause the metric buffer to overflow and metrics to be dropped.