### PR TITLE
Fix icinga2 memory usage, fixed graylog gelf configuration

### DIFF
--- a/icinga2/features/gelf.conf
+++ b/icinga2/features/gelf.conf
@@ -6,7 +6,7 @@
 
 object GelfWriter "gelf" {
   // graylog@ffmuc
-  host = "{{ salt['pillar.get']('netbox:services:graylog_graylog_1:virtual_machine:name', 'localhost') }}"
+  host = "log.ov.ffmuc.net"
   port = 12201
   source = "{{ grains.id }}"
 }

--- a/nebula/files/config.yml.jinja
+++ b/nebula/files/config.yml.jinja
@@ -127,6 +127,10 @@ firewall:
   - port: 5044
     proto: tcp
     host: any
+    # Allow pushing to graylog via gelf
+  - port: 12201
+    proto: tcp
+    host: any
 {%- endif %}
 {%- if "docker04.in.ffmuc.net" == grains["id"] %}
   # Allow connections for draw


### PR DESCRIPTION
icinga2 was eating up all of its memory within a week, as it could no longer connect to the graylog server using gelf. Changed gelf host to "log.ov.ffmuc.net" in icinga2 configuration and adapted nebula config.yml of docker06 (log) to accept connections on gelf port 12201.