### PR TITLE
Update icinga2 init.sls as gelf.conf was no longer updated

### DIFF
--- a/icinga2/init.sls
+++ b/icinga2/init.sls
@@ -6,8 +6,7 @@
 
 {%- if 'icinga2_server' in salt['pillar.get']('netbox:tag_list', []) %}
 # server should send states to graylog
-{%- set icinga2_features = ["gelf"] %}
-{%- set icinga2_features = ["api"] %}
+{%- set icinga2_features = ["api", "gelf"] %}
 {%- else %}
 # Nodes should accept config and commands from Icinga2 server
 {%- set icinga2_features = ["api"] %}


### PR DESCRIPTION
Instead of appending to or changing the array, it was overriden with the additional entry, so gelf.conf was no longer updated by saltstack.