### PR TITLE
Fixed issue with dropped telegraf metrics by increasing batch size

### DIFF
--- a/telegraf/files/telegraf.conf
+++ b/telegraf/files/telegraf.conf
@@ -5,11 +5,11 @@
 [agent]
   interval = "10s"
   round_interval = true
-  metric_batch_size = 1000
-  metric_buffer_limit = 10000
+  metric_batch_size = 2000
+  metric_buffer_limit = 20000
   collection_jitter = "0s"
   flush_interval = "10s"
-  flush_jitter = "0s"
+  flush_jitter = "5s"
   precision = ""
   hostname = "{{ grains.id | regex_replace('\.in\.ffmuc\.net','') }}"
   omit_hostname = false


### PR DESCRIPTION
Current configuration of telegraf is transferring 1000 metrics every 10 seconds to InfluxDB. Gateways currently generate about 2000 metrics within 10 seconds, so only half of them were sent, while the rest was buffered. This was causing the buffer to fill up within a few minutes and following metrics to be dropped. This change increases metric batch size to 2000, metric buffer size to 20000 and sets flush_jitter to 5 seconds, to be able to cope with the current amount of metrics.