### PR TITLE
Remove AdvRouterAddr as it is no longer needed

### DIFF
--- a/radvd/radvd.conf
+++ b/radvd/radvd.conf
@@ -23,7 +23,6 @@ interface br-{{ site }}
         {
                 AdvOnLink on;
                 AdvAutonomous on;
-                AdvRouterAddr on;
                 AdvPreferredLifetime 3600;
                 AdvValidLifetime 7200;
         };


### PR DESCRIPTION
Removed "AdvRouterAddr on" from the prefix configuration, this was a relict from the old "::/64" prefix configuration.

@fixes https://github.com/freifunkMUC/ffmuc-salt-public/issues/33