### PR TITLE
Add logging which user logged in as root

### DIFF
--- a/ssh/authorized_keys.tmpl
+++ b/ssh/authorized_keys.tmpl
@@ -1,4 +1,4 @@
 {% set admins = salt['pillar.get']('netbox:config_context:ssh_user_keys:admins') %}
 {%- for admin in admins|sort -%}
-{{ admins[admin] }}
+environment="SSH_USER={{ admin }}" {{ admins[admin] }}
 {% endfor %}

--- a/ssh/init.sls
+++ b/ssh/init.sls
@@ -26,6 +26,13 @@ ssh:
     - watch_in:
       - service: ssh
 
+/etc/ssh/sshrc:
+  file.managed:
+    - source:
+      - salt://ssh/sshrc
+    - user: root
+    - group: root
+    - mode: "0644"
 
 {% for group in user_groups|sort %}
 {% for user in user_groups[group]|sort %}

--- a/ssh/sshd_config
+++ b/ssh/sshd_config
@@ -95,7 +95,7 @@ X11Forwarding yes
 PrintMotd no
 #PrintLastLog yes
 #TCPKeepAlive yes
-#PermitUserEnvironment no
+PermitUserEnvironment yes
 #Compression delayed
 #ClientAliveInterval 0
 #ClientAliveCountMax 3

--- a/ssh/sshrc
+++ b/ssh/sshrc
@@ -1,0 +1,7 @@
+#!/bin/bash
+ 
+if [ "$SSH_USER" = "" ]; then
+    logger -pauth.info "Login by unknown user as \"$USER\". \$SSH_CLIENT=$SSH_CLIENT."
+else
+    logger -pauth.info "Login by \"$SSH_USER\" as \"$USER\". \$SSH_CLIENT=$SSH_CLIENT."
+fi


### PR DESCRIPTION
Inspired by:
http://screenage.de/blog/2012/02/10/how-to-log-history-and-logins-from-multiple-ssh-keys-under-one-user-account-with-puppet/

Related to:
https://chat.ffmuc.net/freifunk/pl/buejn1o6epb88p5dtyzfk1zt4c