### PR TITLE
Generate certificate for  muenchen.freifunk.net

### DIFF
--- a/certs/init.sls
+++ b/certs/init.sls
@@ -109,6 +109,8 @@ ffmuc-wildcard-cert:
         - "*.freifunk-muenchen.net"
         - "xn--freifunk-mnchen-8vb.de"
         - "*.xn--freifunk-mnchen-8vb.de"
+        - "muenchen.freifunk.net"
+        - "*.muenchen.freifunk.net"
   {% else %}{# "jitsi meet" in role #}
     - name: meet.ffmuc.net
     - aliases:


### PR DESCRIPTION
Merge as soon as @GoliathLabs managed to get the DNS zone delegated to us :).