### PR TITLE
Add github-downloader for scripts used to download build results

### DIFF
--- a/github-downloader/ffmeet-downloader
+++ b/github-downloader/ffmeet-downloader
@@ -1,0 +1,21 @@
+#!/bin/bash
+URLS=$(curl -s https://api.github.com/repos/freifunkMUC/jitsi-meet-electron/releases/latest | jq .assets[].browser_download_url | tr -d \")
+TAG=$(curl -s https://api.github.com/repos/freifunkMUC/jitsi-meet-electron/releases/latest | jq .tag_name | tr -d \")
+
+echo "Latest tag is $TAG"
+
+FIRMWARE_DIR=/srv/www/apt.ffmuc.net/ffmeet/latest
+TEMP_DIR=/tmp/ffmeet/$TAG
+if [ ! -f $FIRMWARE_DIR/$TAG ];
+then
+        echo "Downloading firmware with tag $TAG"
+        mkdir -p $TEMP_DIR 
+        cd $TEMP_DIR
+        touch $FIRMWARE_DIR/$TAG
+        for i in $URLS;
+        do
+                wget -q $i
+        done
+        mv $TEMP_DIR/* $FIRMWARE_DIR/
+        rm -r $TEMP_DIR
+fi

--- a/github-downloader/firmware-downloader
+++ b/github-downloader/firmware-downloader
@@ -1,0 +1,38 @@
+#!/bin/bash
+if [ -z "$1" ]
+then
+    URLS=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases/latest | jq .assets[].browser_download_url | tr -d \")
+    TAG=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases/latest | jq .tag_name | tr -d \")
+else
+    TAG=$1
+    ID=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases | jq '.[] | "\(.tag_name) \(.id)"' | grep $1 | cut -d" " -f2 | sed 's/"//g')
+    URLS=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases/$ID | jq .assets[].browser_download_url | tr -d \")
+fi
+
+
+echo "Latest tag is $TAG"
+
+FIRMWARE_DIR=/srv/www/firmware.ffmuc.net/$TAG
+TEMP_DIR=/tmp/firmware/$TAG
+if [ ! -d $FIRMWARE_DIR ];
+then
+        echo "Downloading firmware with tag $TAG"
+        mkdir -p $FIRMWARE_DIR $TEMP_DIR $TEMP_DIR/extracted
+        cd $TEMP_DIR
+        for i in $URLS;
+        do
+                wget -q $i
+        done
+        for file in `ls *.tar.gz`;
+        do
+                tar xzvf $file -C $TEMP_DIR/extracted
+        done
+        cp extracted/ar71xx-generic_output/images/sysupgrade/*manifest extracted/experimental.manifest
+        for manifest in `ls extracted/*/images/sysupgrade/*manifest | grep -v ar71xx-generic`;
+        do
+                tail -n +5 $manifest >> extracted/experimental.manifest
+        done
+        cp -r extracted/*/debug extracted/*/images/* extracted/*/packages $FIRMWARE_DIR/
+        cp extracted/experimental.manifest $FIRMWARE_DIR/sysupgrade/experimental.manifest
+        rm -r $TEMP_DIR
+fi

--- a/github-downloader/init.sls
+++ b/github-downloader/init.sls
@@ -1,0 +1,9 @@
+### github-downloader rules
+/usr/local/bin/firmware-downloader:
+  file.managed:
+    - source: salt://github-downloader/firmware-downloader
+    - mode: "0755"
+/usr/local/bin/ffmeet-downloader:
+  file.managed:
+    - source: salt://github-downloader/ffmeet-downloader
+    - mode: "0755"

--- a/top.sls
+++ b/top.sls
@@ -57,5 +57,6 @@ base:
   'webfrontend0[3-6].in.ffmuc.net':
     - dns-server/auth
     - pdns-recursor
+    - github-downloader
   'vpn0*.in.ffmuc.net':
     - wireguard


### PR DESCRIPTION
Moves the shell scripts firmware-downloader.sh and ffmeet-downloader.sh, currently residing in /root of webfrontends, to salt and create /usr/local/bin/firmware-downloader and /usr/local/bin/ffmeet-downloader on webfrontends.