### PR TITLE
Revert "Update tiles.ffmuc.net.conf"

### DIFF
--- a/nginx/domains/tiles.ffmuc.net.conf
+++ b/nginx/domains/tiles.ffmuc.net.conf
@@ -7,9 +7,8 @@ upstream osm {
 }
 
 upstream osmhot { 
-	server a.tile.openstreetmap.org;
-	server b.tile.openstreetmap.org;
-	server c.tile.openstreetmap.org;
+	server a.tile.openstreetmap.fr;
+	server b.tile.openstreetmap.fr;
 	keepalive 8;
 }
 


### PR DESCRIPTION
This reverts commit d7af1d7e7fc5d3472a18aca625ab075b23f3b0b2.

redundant `location /osm/` and `location /hot/` blocks don't make sense

I would try to address this with https://github.com/freifunkMUC/meshviewer/pull/4/

relevant for https://github.com/freifunkMUC/ffmuc-salt-public/issues/55