### PR TITLE
Added: FFA domain

### DIFF
--- a/wgkex/wgkex.yaml
+++ b/wgkex/wgkex.yaml
@@ -1,6 +1,7 @@
 ---
 
 domains:
+  - ffmuc_augsburg
   - ffmuc_freising
   - ffmuc_gauting
   - ffmuc_muc_cty


### PR DESCRIPTION
Added FFA domain to wgkex.yaml.

Needed for:
https://github.com/freifunkMUC/site-ffm/pull/151