### PR TITLE
github-downloader: Grep more specific to not confuse regular and next firmware

### DIFF
--- a/github-downloader/firmware-downloader
+++ b/github-downloader/firmware-downloader
@@ -5,7 +5,7 @@ then
     TAG=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases/latest | jq .tag_name | tr -d \")
 else
     TAG=$1
-    ID=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases | jq '.[] | "\(.tag_name) \(.id)"' | grep $1 | cut -d" " -f2 | sed 's/"//g')
+    ID=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases | jq '.[] | "\(.tag_name) \(.id)"' | grep \"$1\  | cut -d" " -f2 | sed 's/"//g')
     URLS=$(curl -s https://api.github.com/repos/freifunkMUC/site-ffm/releases/$ID | jq .assets[].browser_download_url | tr -d \")
 fi
 


### PR DESCRIPTION
When next-firmware is already available at the time firmware-downloader is executed, it accidentally downloads the next-firmware instead of the regular firmware.