### PR TITLE
Added: server redirect to legacy devices post

### DIFF
--- a/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
+++ b/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
@@ -1,0 +1,16 @@
+
+server {
+    listen 80;
+    listen [::]:80;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name bitte-router-erneuern.ffmuc.net;
+
+    return 301 https://ffmuc.net/freifunkmuc/2019/07/11/austausch-aelterer-geraete/;
+
+    ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
+
+    access_log /var/log/nginx/{{ domain }}_access.log json_normal;
+    error_log  /var/log/nginx/{{ domain }}_error.log;
+}


### PR DESCRIPTION
I've added a server directive to redirect bitte-router-erneuern.ffmuc.net to the corresponding post on our homepage (https://ffmuc.net/freifunkmuc/2019/07/11/austausch-aelterer-geraete/)