### PR TITLE
dnsdist: Answer RFC1918 PTR queries with NXDOMAIN, UDP ANY with tc=1

### DIFF
--- a/dnsdist/dnsdist.conf.j2
+++ b/dnsdist/dnsdist.conf.j2
@@ -7,9 +7,9 @@ end
 --- now the real config
 
 setACL({'0.0.0.0/0', '::/0'})
--- drop ANY queries sent over udp , not useful for DoT and DoH only servers.
-addAction(AndRule({QTypeRule(DNSQType.ANY), TCPRule(false)}), DropAction())
-addAction(RegexRule(".*\\.(10|168\\.192|(1[6-9]|2[0-9]|3[0-1])\\.172)\\.in-addr\\.arpa$"), DropAction())
+-- respond to ANY queries sent over UDP with the TC bit set, shunting to TCP.
+addAction(AndRule({QTypeRule(DNSQType.ANY), TCPRule(false)}), TCAction())
+addAction(RegexRule(".*\\.(10|168\\.192|(1[6-9]|2[0-9]|3[0-1])\\.172)\\.in-addr\\.arpa$"), RCodeAction(DNSRCode.NXDOMAIN))
 
 addLocal("0.0.0.0")
 addLocal("::")


### PR DESCRIPTION
Dropping the RFC1918 PTR queries causes clients to repeat the request with multi-second delays until a timeout is hit, which makes e.g. traceroutes with hops in private IP address space really slow, and also causes slightly higher load due to the repeated queries.

And for ANY queries over UDP it is common to respond with the TC bit set, redirecting them to TCP.
This presumably hasn't been done before because the DNS servers were only meant to be reachable for DoT and DoH clients.

- https://dnsdist.org/rules-actions.html#TCAction
- https://dnsdist.org/rules-actions.html#RCodeAction
- https://dnsdist.org/reference/constants.html#dnsrcode