### PR TITLE
Set black to python2 compatible version

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@21.12b0
+      - uses: psf/black@21.10b0
         with:
           # yamllint disable-line rule:line-length
           options: ". --exclude respondd/respondd-tmpl/lib/respondd_client.py --check --diff"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@21.10b0
+      - uses: psf/black@stable
         with:
           # yamllint disable-line rule:line-length
           options: ". --exclude respondd/respondd-tmpl/lib/respondd_client.py --check --diff"
+          version: "21.12b0"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: psf/black@main
+      - uses: psf/black@21.12b0
         with:
           # yamllint disable-line rule:line-length
           options: ". --exclude respondd/respondd-tmpl/lib/respondd_client.py --check --diff"


### PR DESCRIPTION
Currently black is failing because we're not using pinned versions of the actions used in our workflows. The most recent release of black did remove python2 support, yet we do have some still sticking around (e.g. in the icinga2 subdirectory). Until we've migrated those to python3 as well, we might want to use a version which still supports python2 in the meantime