### PR TITLE
Added: Fnmuc.net.conf vhost nginx

### DIFF
--- a/nginx/domains/fnmuc.net.conf
+++ b/nginx/domains/fnmuc.net.conf
@@ -1,0 +1,16 @@
+
+server {
+    listen 80;
+    listen [::]:80;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name fnmuc.net
+
+    return 301 https://ffmuc.net;
+
+    ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
+
+    access_log /var/log/nginx/{{ domain }}_access.log json_normal;
+    error_log  /var/log/nginx/{{ domain }}_error.log;
+}

--- a/nginx/domains/fnmuc.net.conf
+++ b/nginx/domains/fnmuc.net.conf
@@ -6,7 +6,7 @@ server {
     listen [::]:443 ssl http2;
     server_name fnmuc.net
 
-    return 301 https://ffmuc.net;
+    return 301 https://ffmuc.net/impressum/;
 
     ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;


### PR DESCRIPTION
Added the fnmuc.net configuration so that t-online now sees that fnmuc.net is connected to ffmuc.net and allows us to send mails to t-online customers.