### PR TITLE
Remove Trailing whitespace in speedtest docker

### DIFF
--- a/docker-containers/speedtest/docker-compose.yml.j2
+++ b/docker-containers/speedtest/docker-compose.yml.j2
@@ -5,7 +5,7 @@ services:
     image: adolfintel/speedtest
     restart: always
     ports:
-      - {{ salt["pillar.get"]("netbox:config_context:docker:speedtest:frontend_port", 80) }}:80 
+      - {{ salt["pillar.get"]("netbox:config_context:docker:speedtest:frontend_port", 80) }}:80
     environment:
       TITLE: "Freifunk München Speedtest"
       MODE: "frontend"
@@ -15,6 +15,6 @@ services:
     image: adolfintel/speedtest
     restart: always
     ports:
-      - {{ salt["pillar.get"]("netbox:config_context:docker:speedtest:backend_port", 8082) }}:80 
+      - {{ salt["pillar.get"]("netbox:config_context:docker:speedtest:backend_port", 8082) }}:80
     environment:
       MODE: "backend"


### PR DESCRIPTION
make Salt Lint happy: https://github.com/freifunkMUC/ffmuc-salt-public/runs/5203024822 by removing Trailing whitespace