### PR TITLE
Added semicolon

### DIFF
--- a/nginx/domains/fnmuc.net.conf
+++ b/nginx/domains/fnmuc.net.conf
@@ -4,7 +4,7 @@ server {
     listen [::]:80;
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name fnmuc.net
+    server_name fnmuc.net;
 
     return 301 https://ffmuc.net/impressum/;
 


### PR DESCRIPTION
We forgot to add the semicolon for the server_name in the nginx server directive. that's why it ain't working