### PR TITLE
Updated: diun to 4.21.0

### DIFF
--- a/docker-containers/diun/docker-compose.yml.j2
+++ b/docker-containers/diun/docker-compose.yml.j2
@@ -1,10 +1,10 @@
 ---
 
-version: "3.5"
+version: "3.8"
 
 services:
   diun:
-    image: crazymax/diun:latest
+    image: crazymax/diun:4.21.0
     hostname: {{ grains.id.split('.')[0] }}-diun
     volumes:
       - "./data:/data"


### PR DESCRIPTION
We should use proper image version tags instead of using the latest tag, because (even if it is very unlikely) things can break after an update in the future