### PR TITLE
Reduce diun output to hostname and image name only

### DIFF
--- a/docker-containers/diun/diun.yml.j2
+++ b/docker-containers/diun/diun.yml.j2
@@ -12,7 +12,8 @@ providers:
 notif:
   slack:
     webhookURL: {{ salt["pillar.get"]("netbox:config_context:docker:diun:webhookURL", "") }}
+    renderFields : false
     templateBody: |
       {% raw -%}
-      Docker tag `{{ .Entry.Image }}` {{ if (eq .Entry.Status "new") }}newly added{{ else }}updated{{ end }}.
+      {{ .Meta.Hostname }}: `{{ .Entry.Image }}` {{ if (eq .Entry.Status "new") }}newly added{{ else }}updated{{ end }}.
       {%- endraw %}


### PR DESCRIPTION
To reduce clutter in the NOC-Monitoring channel, remove repetitive info from the diun messages.