### PR TITLE
Make salt-linter happy again

### DIFF
--- a/jitsi/videobridge/jvb.conf.jinja
+++ b/jitsi/videobridge/jvb.conf.jinja
@@ -27,7 +27,7 @@ videobridge {
     http-servers {
         public {
             # TODO: Split this to own var 
-            host = {{ jitsi.videobridge.octo.ip_addr | default("127.0.0.1")}}
+            host = {{ jitsi.videobridge.octo.ip_addr | default("127.0.0.1") }}
             port = 9090
         }
         private {


### PR DESCRIPTION
With https://github.com/freifunkMUC/ffmuc-salt-public/commit/08977e4fd06f768f7ed44faf6e15dfa92b9cbe0c a small linting-bug was introduced, which causes the salt-linter to no longer be happy. The PR should fix this.