### PR TITLE
Added: augsburg.freifunk.net

### DIFF
--- a/certs/init.sls
+++ b/certs/init.sls
@@ -156,8 +156,6 @@ ffmuc-wildcard-cert:
         - "*.muenchen.freifunk.net"
         - "xn--mnchen-3ya.freifunk.net"
         - "*.xn--mnchen-3ya.freifunk.net"
-        - "augsburg.freifunk.net"
-        - "*.augsburg.freifunk.net"
   {% else %}{# "jitsi meet" in role #}
     - name: meet.ffmuc.net
     - aliases:
@@ -179,6 +177,19 @@ ffmuc-wildcard-cert:
         - pip: acme-client
         - file: dns_credentials
 
+augsburg.freifunk.net-cert:
+  acme.cert:
+  {% if "webserver-external" in role %}
+    - name: augsburg.freifunk.net
+    - email: hilfe@ffmuc.bayern
+    - owner: root
+    - group: ssl-cert
+    - mode: "0640"
+    #- renew: True
+    - require:
+        - cmd: certbot
+        - pip: acme-client
+    
 /etc/letsencrypt/renewal-hooks/deploy/01-reload-nginx.sh:
   file.managed:
     - contents: |

--- a/certs/init.sls
+++ b/certs/init.sls
@@ -189,7 +189,7 @@ augsburg.freifunk.net-cert:
     - require:
         - cmd: certbot
         - pip: acme-client
- 
+
 /etc/letsencrypt/renewal-hooks/deploy/01-reload-nginx.sh:
   file.managed:
     - contents: |

--- a/certs/init.sls
+++ b/certs/init.sls
@@ -189,7 +189,7 @@ augsburg.freifunk.net-cert:
     - require:
         - cmd: certbot
         - pip: acme-client
-    
+ 
 /etc/letsencrypt/renewal-hooks/deploy/01-reload-nginx.sh:
   file.managed:
     - contents: |

--- a/certs/init.sls
+++ b/certs/init.sls
@@ -152,10 +152,6 @@ ffmuc-wildcard-cert:
         - "*.freifunk-muenchen.net"
         - "xn--freifunk-mnchen-8vb.de"
         - "*.xn--freifunk-mnchen-8vb.de"
-        - "muenchen.freifunk.net"
-        - "*.muenchen.freifunk.net"
-        - "xn--mnchen-3ya.freifunk.net"
-        - "*.xn--mnchen-3ya.freifunk.net"
   {% else %}{# "jitsi meet" in role #}
     - name: meet.ffmuc.net
     - aliases:
@@ -177,14 +173,21 @@ ffmuc-wildcard-cert:
         - pip: acme-client
         - file: dns_credentials
 
-augsburg.freifunk.net-cert:
+ffmuc-non-wildcard-cert:
   acme.cert:
   {% if "webserver-external" in role %}
-    - name: augsburg.freifunk.net
+    - name: muenchen.freifunk.net
+    - aliases:
+        - "www.muenchen.freifunk.net"
+        - "xn--mnchen-3ya.freifunk.net"
+        - "www.xn--mnchen-3ya.freifunk.net"
+        - "augsburg.freifunk.net"
+        - "www.augsburg.freifunk.net"
     - email: hilfe@ffmuc.bayern
     - owner: root
     - group: ssl-cert
     - mode: "0640"
+    - 
     #- renew: True
     - require:
         - cmd: certbot

--- a/certs/init.sls
+++ b/certs/init.sls
@@ -187,7 +187,7 @@ ffmuc-non-wildcard-cert:
     - owner: root
     - group: ssl-cert
     - mode: "0640"
-    - 
+    - http_01_port: 9999
     #- renew: True
     - require:
         - cmd: certbot

--- a/nginx/domains/ffmuc.net-non-wildcard.conf
+++ b/nginx/domains/ffmuc.net-non-wildcard.conf
@@ -12,15 +12,11 @@ upstream wiki_upstream {
 server {
 	listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name ffmuc.net 
-        www.muenchen.freifunk.net muenchen.freifunk.net
+    server_name muenchen.freifunk.net
+        www.muenchen.freifunk.net
         www.münchen.freifunk.net münchen.freifunk.net
         www.xn--mnchen-3ya.freifunk.net xn--mnchen-3ya.freifunk.net
-        www.augsburg.freifunk.net augsburg.freifunk.net
-        www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
-        www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net
-        www.xn--freifunk-mnchen-8vb.de xn--freifunk-mnchen-8vb.de
-        www.freifunk-münchen.de freifunk-münchen.de;
+        www.augsburg.freifunk.net augsburg.freifunk.net;
     
     # Force HTTPS connection. This rules is domain agnostic
     if ($scheme != "https") {
@@ -112,30 +108,38 @@ server {
     location /podcast/ {
         deny all;
     }
-    ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/muenchen.freifunk.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/muenchen.freifunk.net/privkey.pem;
 
     access_log /var/log/nginx/hp.ffmuc.net_access.log json_normal;
     error_log /var/log/nginx/hp.ffmuc.net_error.log;
+    ProxyPass "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/" retry=1
+    ProxyPassReverse "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/"
+
+    <Location "/.well-known/acme-challenge/">
+        ProxyPreserveHost On
+        Order allow,deny
+        Allow from all
+        Require all granted
+    </Location>
 }
 
 server {
     listen 80;
 	listen [::]:80;
-    server_name ffmuc.net 
-        www.ffmuc.net 
-        wiki.ffmuc.net
-        hp.ffmuc.net
-        hp.ext.ffmuc.net
-        www.freewifi.bayern freewifi.bayern 
-        www.ffmuc.bayern ffmuc.bayern 
-        www.muenchen.freifunk.net muenchen.freifunk.net
+    server_name muenchen.freifunk.net
+        www.muenchen.freifunk.net
         www.münchen.freifunk.net münchen.freifunk.net
         www.xn--mnchen-3ya.freifunk.net xn--mnchen-3ya.freifunk.net
-        www.augsburg.freifunk.net augsburg.freifunk.net
-        www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
-        www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net
-        www.xn--freifunk-mnchen-8vb.de xn--freifunk-mnchen-8vb.de
-        www.freifunk-münchen.de freifunk-münchen.de;
+        www.augsburg.freifunk.net augsburg.freifunk.net;
     return 301 https://$host$request_uri;
+    ProxyPass "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/" retry=1
+    ProxyPassReverse "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/"
+
+    <Location "/.well-known/acme-challenge/">
+        ProxyPreserveHost On
+        Order allow,deny
+        Allow from all
+        Require all granted
+    </Location>
 }

--- a/nginx/domains/ffmuc.net-non-wildcard.conf
+++ b/nginx/domains/ffmuc.net-non-wildcard.conf
@@ -113,15 +113,12 @@ server {
 
     access_log /var/log/nginx/hp.ffmuc.net_access.log json_normal;
     error_log /var/log/nginx/hp.ffmuc.net_error.log;
-    ProxyPass "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/" retry=1
-    ProxyPassReverse "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/"
-
-    <Location "/.well-known/acme-challenge/">
-        ProxyPreserveHost On
-        Order allow,deny
-        Allow from all
-        Require all granted
-    </Location>
+    location /.well-known/acme-challenge/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://127.0.0.1:9999/.well-known/acme-challenge/;
+    }
 }
 
 server {
@@ -133,13 +130,11 @@ server {
         www.xn--mnchen-3ya.freifunk.net xn--mnchen-3ya.freifunk.net
         www.augsburg.freifunk.net augsburg.freifunk.net;
     return 301 https://$host$request_uri;
-    ProxyPass "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/" retry=1
-    ProxyPassReverse "/.well-known/acme-challenge/" "http://127.0.0.1:9999/.well-known/acme-challenge/"
 
-    <Location "/.well-known/acme-challenge/">
-        ProxyPreserveHost On
-        Order allow,deny
-        Allow from all
-        Require all granted
-    </Location>
+    location /.well-known/acme-challenge/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://127.0.0.1:9999/.well-known/acme-challenge/;
+    }
 }


### PR DESCRIPTION
The augsburg.freifunk.net domain has been put into a separate section because we use acme http instead of dns validation here. Wildcard certificates are not possible without DNS delegation.

Can someone please have a look over this as it is my first time messing with acme states in salt