### PR TITLE
Upgrade yanic deb to 1.2.1

### DIFF
--- a/yanic/init.sls
+++ b/yanic/init.sls
@@ -12,7 +12,7 @@
 yanic:
   pkg.installed:
     - sources:
-      - yanic: http://apt.ffmuc.net/yanic_1.2.1-1_amd64.deb
+      - yanic: https://apt.ffmuc.net/yanic_1.2.1-1_amd64.deb
 
 # copy systemd yanic@.service
 /etc/systemd/system/yanic@.service:


### PR DESCRIPTION
Let's try upgrading yanic!
Should hopefully resolve some of the issues that have been encountered, especially when InfluxDB was down/unreachable.

@GoliathLabs thankfully uploaded the deb to apt.ffmuc.net. This changes the path in the corresponding init.sls. Please test after upgrading to make sure everything still works.