### PR TITLE
replace apt-key by keyring usage

### DIFF
--- a/apt/init.sls
+++ b/apt/init.sls
@@ -9,19 +9,31 @@
 /etc/apt/sources.list.d/repo_saltstack_com_apt_debian_9_amd64_latest.list:
   file.absent
 
+salt-repo-key:
+  file.managed:
+    - name: /usr/share/keyrings/salt-archive-keyring.gpg
+    {% if 'Ubuntu' in grains.lsb_distrib_id %}
+    - source: https://repo.saltproject.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg
+    {% elif 'Raspbian' in grains.lsb_distrib_id %}
+    - source: http://repo.saltstack.io/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg
+    {% else %}
+    - source: http://repo.saltstack.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg # noqa: 204
+    {% endif %}
+    - skip_verify: True
+
 salt-repo:
   pkgrepo.managed:
-    - humanname: SaltStack-
     {% if 'Ubuntu' in grains.lsb_distrib_id %}
-    - name: deb [arch={{ grains.osarch }}] http://repo.saltstack.com/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltstack.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
     {% elif 'Raspbian' in grains.lsb_distrib_id %}
-    - name: deb [arch={{ grains.osarch }}] http://repo.saltstack.com/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltstack.io/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
     {% else %}
-    - name: deb [arch={{ grains.osarch }}] http://repo.saltstack.com/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/3000 {{ grains.oscodename }} main # noqa: 204
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltstack.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main # noqa: 204
     {% endif %}
-    - dist: {{ grains.oscodename }}
     - file: /etc/apt/sources.list.d/saltstack.list
     - clean_file: True
+    - require:
+      - file: salt-repo-key
 
 /etc/cron.d/apt:
   file.managed:

--- a/dnsdist/init.sls
+++ b/dnsdist/init.sls
@@ -3,12 +3,18 @@
 #
 {% if 'dnsdist' in salt['pillar.get']('netbox:tag_list', []) %}
 
+dnsdist-repo-key:
+  cmd.run:
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/FD380FBB-keyring.gpg"
+    - creates: /usr/share/keyrings/FD380FBB-keyring.gpg
+
 dnsdist-repo:
   pkgrepo.managed:
-    - name: deb [arch={{ grains.osarch }}] https://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-dnsdist-17 main
-    - clean_file: True
-    - key_url: https://repo.powerdns.com/FD380FBB-pub.asc
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/FD380FBB-keyring.gpg] https://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-dnsdist-17 main
     - file: /etc/apt/sources.list.d/dnsdist.list
+    - clean_file: True
+    - require:
+      - cmd: dnsdist-repo-key
 
 dnsdist:
   pkg.installed:

--- a/dnsdist/init.sls
+++ b/dnsdist/init.sls
@@ -5,12 +5,12 @@
 
 dnsdist-repo-key:
   cmd.run:
-    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/FD380FBB-keyring.gpg"
-    - creates: /usr/share/keyrings/FD380FBB-keyring.gpg
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/powerdns-keyring.gpg"
+    - creates: /usr/share/keyrings/powerdns-keyring.gpg
 
 dnsdist-repo:
   pkgrepo.managed:
-    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/FD380FBB-keyring.gpg] https://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-dnsdist-17 main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/powerdns-keyring.gpg] https://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-dnsdist-17 main
     - file: /etc/apt/sources.list.d/dnsdist.list
     - clean_file: True
     - require:

--- a/dnsdist/init.sls
+++ b/dnsdist/init.sls
@@ -5,7 +5,7 @@
 
 dnsdist-repo-key:
   cmd.run:
-    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/powerdns-keyring.gpg"
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor -o /usr/share/keyrings/powerdns-keyring.gpg"
     - creates: /usr/share/keyrings/powerdns-keyring.gpg
 
 dnsdist-repo:

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -6,7 +6,7 @@
 {% if 'docker' in role or 'mailserver' in role or 'roadwarrior' in role %}
 docker-repo-key:
   cmd.run:
-    - name: "curl https://download.docker.com/linux/{{ grains.lsb_distrib_id | lower }}/gpg | gpg --dearmor > /usr/share/keyrings/docker-keyring.gpg"
+    - name: "curl https://download.docker.com/linux/{{ grains.lsb_distrib_id | lower }}/gpg | gpg --dearmor -o /usr/share/keyrings/docker-keyring.gpg"
     - creates: /usr/share/keyrings/docker-keyring.gpg
 
 docker-repo:

--- a/grafana/init.sls
+++ b/grafana/init.sls
@@ -3,13 +3,20 @@
 #
 {% if 'grafana_server' in salt['pillar.get']('netbox:tag_list', []) %}
 
+grafana-repo-key:
+  cmd.run:
+    - name: "curl https://packages.grafana.com/gpg.key | gpg --dearmor > /usr/share/keyrings/grafana-keyring.gpg"
+    - creates: /usr/share/keyrings/grafana-keyring.gpg
+
 grafana:
 # add Grafana Repo
   pkgrepo.managed:
     - humanname: Grafana Repo
-    - name: deb [arch={{ grains.osarch }}] https://packages.grafana.com/oss/deb stable main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/grafana-keyring.gpg] https://packages.grafana.com/oss/deb stable main
     - file: /etc/apt/sources.list.d/grafana.list
-    - key_url: https://packages.grafana.com/gpg.key
+    - clean_file: True
+    - require:
+      - cmd: grafana-repo-key
 # install grafana
   pkg.installed:
     - name: grafana

--- a/grafana/init.sls
+++ b/grafana/init.sls
@@ -5,7 +5,7 @@
 
 grafana-repo-key:
   cmd.run:
-    - name: "curl https://packages.grafana.com/gpg.key | gpg --dearmor > /usr/share/keyrings/grafana-keyring.gpg"
+    - name: "curl https://packages.grafana.com/gpg.key | gpg --dearmor -o /usr/share/keyrings/grafana-keyring.gpg"
     - creates: /usr/share/keyrings/grafana-keyring.gpg
 
 grafana:

--- a/graylog-sidecar/init.sls
+++ b/graylog-sidecar/init.sls
@@ -8,20 +8,33 @@ graylog-sidecar-pkg:
 
 {% else %}{# if grains.osfullname in 'Raspbian' #}
 
+graylog-repo-key:
+  cmd.run:
+    - name: "curl https://packages.graylog2.org/repo/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/graylog-keyring.gpg"
+    - creates: /usr/share/keyrings/graylog-keyring.gpg
+
 graylog-repo:
     pkgrepo.managed:
     - humanname: Graylog-Repo
-    - name: deb [arch={{ grains.osarch }}] https://packages.graylog2.org/repo/debian/ sidecar-stable 1.1
-    - key_url:  https://packages.graylog2.org/repo/debian/pubkey.gpg
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/graylog-keyring.gpg] https://packages.graylog2.org/repo/debian/ sidecar-stable 1.1
     - file: /etc/apt/sources.list.d/graylog-sidecar.list
     - clean_file: True
+    - require:
+      - cmd: graylog-repo-key
+
+elasticsearch-repo-key:
+  cmd.run:
+    - name: "curl https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor > /usr/share/keyrings/elasticsearch-keyring.gpg"
+    - creates: /usr/share/keyrings/elasticsearch-keyring.gpg
 
 filebeat-repo:
   pkgrepo.managed:
     - humanname: Elastic-Repo
-    - name: deb [arch={{ grains.osarch }}] https://artifacts.elastic.co/packages/oss-7.x/apt stable main
-    - key_url:  https://artifacts.elastic.co/GPG-KEY-elasticsearch
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/oss-7.x/apt stable main
     - file: /etc/apt/sources.list.d/elastic-7.x.list
+    - clean_file: True
+    - require:
+      - cmd: elasticsearch-repo-key
 
 {% endif %}
 

--- a/graylog-sidecar/init.sls
+++ b/graylog-sidecar/init.sls
@@ -10,7 +10,7 @@ graylog-sidecar-pkg:
 
 graylog-repo-key:
   cmd.run:
-    - name: "curl https://packages.graylog2.org/repo/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/graylog-keyring.gpg"
+    - name: "curl https://packages.graylog2.org/repo/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/graylog-keyring.gpg"
     - creates: /usr/share/keyrings/graylog-keyring.gpg
 
 graylog-repo:
@@ -24,7 +24,7 @@ graylog-repo:
 
 elasticsearch-repo-key:
   cmd.run:
-    - name: "curl https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor > /usr/share/keyrings/elasticsearch-keyring.gpg"
+    - name: "curl https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg"
     - creates: /usr/share/keyrings/elasticsearch-keyring.gpg
 
 filebeat-repo:

--- a/icinga2/init.sls
+++ b/icinga2/init.sls
@@ -18,7 +18,7 @@ include:
 
 icinga2-repo-key:
   cmd.run:
-    - name: "curl https://packages.icinga.org/icinga.key | gpg --dearmor > /usr/share/keyrings/icinga2-keyring.gpg"
+    - name: "curl https://packages.icinga.org/icinga.key | gpg --dearmor -o /usr/share/keyrings/icinga2-keyring.gpg"
     - creates: /usr/share/keyrings/icinga2-keyring.gpg
 
 icinga2-repo:

--- a/icinga2/init.sls
+++ b/icinga2/init.sls
@@ -16,18 +16,24 @@ include:
   - apt
   - sudo
 
+icinga2-repo-key:
+  cmd.run:
+    - name: "curl https://packages.icinga.org/icinga.key | gpg --dearmor > /usr/share/keyrings/icinga2-keyring.gpg"
+    - creates: /usr/share/keyrings/icinga2-keyring.gpg
+
 icinga2-repo:
   pkgrepo.managed:
     {% if grains.osfullname in 'Raspbian' %}
-    - name: deb https://packages.icinga.com/raspbian icinga-{{ grains.oscodename }} main
+    - name: deb [signed-by=/usr/share/keyrings/icinga2-keyring.gpg] https://packages.icinga.com/raspbian icinga-{{ grains.oscodename }} main
     {% elif grains.osfullname in 'Ubuntu' %}
-    - name: deb [arch={{ grains.osarch }}] https://packages.icinga.com/{{ grains.lsb_distrib_id | lower }} icinga-{{ grains.oscodename }} main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/icinga2-keyring.gpg] https://packages.icinga.com/{{ grains.lsb_distrib_id | lower }} icinga-{{ grains.oscodename }} main
     {% else %}
-    - name: deb https://packages.icinga.com/debian icinga-{{ grains.oscodename }} main
+    - name: deb [signed-by=/usr/share/keyrings/icinga2-keyring.gpg] https://packages.icinga.com/debian icinga-{{ grains.oscodename }} main
     {% endif %}
     - file: /etc/apt/sources.list.d/icinga2.list
-    - key_url: https://packages.icinga.org/icinga.key
     - clean_file: True
+    - require:
+      - cmd: icinga2-repo-key
 
 # Install icinga2 package
 {% set node_config = salt['pillar.get']('nodes:' ~ grains.id, {}) %}

--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -2,12 +2,18 @@
 # influxdb
 #
 {%- if 'influxdb_server' in salt['pillar.get']('netbox:tag_list', []) %}
+influxdb-repo-key:
+  cmd.run:
+    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor > /usr/share/keyrings/influxdb-keyring.gpg"
+    - creates: /usr/share/keyrings/influxdb-keyring.gpg
 
 influxdb-repo:
   pkgrepo.managed:
-    - name: deb https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }} stable
-    - key_url:  https://repos.influxdata.com/influxdb.key
+    - name: deb [signed-by=/usr/share/keyrings/influxdb-keyring.gpg] https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }} stable
     - file: /etc/apt/sources.list.d/influxdb.list
+    - clean_file: True
+    - require:
+      - cmd: influxdb-repo-key
 
 influxdb-pkg:
   pkg.installed:

--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -4,7 +4,7 @@
 {%- if 'influxdb_server' in salt['pillar.get']('netbox:tag_list', []) %}
 influxdb-repo-key:
   cmd.run:
-    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor > /usr/share/keyrings/influxdb-keyring.gpg"
+    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor -o /usr/share/keyrings/influxdb-keyring.gpg"
     - creates: /usr/share/keyrings/influxdb-keyring.gpg
 
 influxdb-repo:

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -10,7 +10,7 @@
 {% if 'buildserver' in role %}
 jenkins-repo-key:
   cmd.run:
-    - name: "curl https://pkg.jenkins.io/debian/jenkins.io.key | gpg --dearmor > /usr/share/keyrings/jenkins-keyring.gpg"
+    - name: "curl https://pkg.jenkins.io/debian/jenkins.io.key | gpg --dearmor -o /usr/share/keyrings/jenkins-keyring.gpg"
     - creates: /usr/share/keyrings/jenkins-keyring.gpg
 
 jenkins:

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -8,16 +8,21 @@
 {% endif %}
 
 {% if 'buildserver' in role %}
+jenkins-repo-key:
+  cmd.run:
+    - name: "curl https://pkg.jenkins.io/debian/jenkins.io.key | gpg --dearmor > /usr/share/keyrings/jenkins-keyring.gpg"
+    - creates: /usr/share/keyrings/jenkins-keyring.gpg
+
 jenkins:
   pkgrepo.managed:
     - comments:
       - "# Jenkins APT repo"
     - human_name: Jenkins repository
-    - name: deb https://pkg.jenkins.io/debian binary/
-    - clean_file: True
-    - dist: binary/
+    - name: deb [signed-by=/usr/share/keyrings/jenkins-keyring.gpg] https://pkg.jenkins.io/debian binary/
     - file: /etc/apt/sources.list.d/pkg_jenkins_io_debian.list
-    - key_url: https://pkg.jenkins.io/debian/jenkins.io.key
+    - clean_file: True
+    - require:
+      - cmd: jenkins-repo-key
     - require_in:
       - pkg: jenkins
 

--- a/jitsi/base.sls
+++ b/jitsi/base.sls
@@ -1,13 +1,13 @@
 jitsi-repo-key:
   cmd.run:
-    - name: "wget https://download.jitsi.org/jitsi-key.gpg.key -qO - | apt-key add -"
-    - unless: 'gpg2 /etc/apt/trusted.gpg | grep FFD65A0DA2BEBDEB73D44C8BB4D2D216F1FD7806'
+    - name: "curl https://download.jitsi.org/jitsi-key.gpg.key | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/jitsi-keyring.gpg'"
+    - creates: /usr/share/keyrings/jitsi-keyring.gpg
 
 jitsi-repo:
   pkgrepo.managed:
     - humanname: Jitsi Repo
-    - name: deb https://download.jitsi.org stable/
-    #- name: deb https://apt.ffmuc.net stable/
+    - name: deb [signed-by=/usr/share/keyrings/jitsi-keyring.gpg] https://download.jitsi.org stable/
     - file: /etc/apt/sources.list.d/jitsi-stable.list
-    #- key: https://download.jitsi.org/jitsi-key.gpg.key
     - clean_file: True
+    - require:
+      - cmd: jitsi-repo-key

--- a/jitsi/base.sls
+++ b/jitsi/base.sls
@@ -1,6 +1,6 @@
 jitsi-repo-key:
   cmd.run:
-    - name: "curl https://download.jitsi.org/jitsi-key.gpg.key | sudo sh -c 'gpg --dearmor > /usr/share/keyrings/jitsi-keyring.gpg'"
+    - name: "curl https://download.jitsi.org/jitsi-key.gpg.key | gpg --dearmor -o /usr/share/keyrings/jitsi-keyring.gpg"
     - creates: /usr/share/keyrings/jitsi-keyring.gpg
 
 jitsi-repo:

--- a/jitsi/jibri/init.sls
+++ b/jitsi/jibri/init.sls
@@ -10,7 +10,7 @@ include:
 
 google-chrome-repo-key:
   cmd.run:
-    - name: "curl https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome-keyring.gpg"
+    - name: "curl https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg"
     - creates: /usr/share/keyrings/google-chrome-keyring.gpg
 
 google-chrome-repo:

--- a/jitsi/jibri/init.sls
+++ b/jitsi/jibri/init.sls
@@ -8,12 +8,19 @@
 include:
   - jitsi.base
 
+google-chrome-repo-key:
+  cmd.run:
+    - name: "curl https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /usr/share/keyrings/google-chrome-keyring.gpg"
+    - creates: /usr/share/keyrings/google-chrome-keyring.gpg
+
 google-chrome-repo:
   pkgrepo.managed:
     - humanname: Google Chrome Repo
-    - name: deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main
     - file: /etc/apt/sources.list.d/google-chrome.list
-    - key_url: https://dl-ssl.google.com/linux/linux_signing_key.pub
+    - clean_file: True
+    - require:
+      - cmd: google-chrome-repo-key
 
 snd_aloop:
   kmod.present:

--- a/jitsi/prosody/init.sls
+++ b/jitsi/prosody/init.sls
@@ -5,13 +5,19 @@
 
 {% if jitsi.prosody.enabled %}
 
+prosody-repo-key:
+  cmd.run:
+    - name: "curl https://prosody.im/files/prosody-debian-packages.key | gpg --dearmor > /usr/share/keyrings/prosody-keyring.gpg"
+    - creates: /usr/share/keyrings/prosody-keyring.gpg
+
 prosody-repo:
   pkgrepo.managed:
     - humanname: Prosody
-    - name: deb http://packages.prosody.im/debian {{ grains.oscodename }} main
+    - name: deb [signed-by=/usr/share/keyrings/prosody-keyring.gpg] http://packages.prosody.im/debian {{ grains.oscodename }} main
     - file: /etc/apt/sources.list.d/prosody.list
-    - key_url: https://prosody.im/files/prosody-debian-packages.key
     - clean_file: True
+    - require:
+      - cmd: prosody-repo-key
 
 prosody-dependencies:
   pkg.installed:

--- a/jitsi/prosody/init.sls
+++ b/jitsi/prosody/init.sls
@@ -7,7 +7,7 @@
 
 prosody-repo-key:
   cmd.run:
-    - name: "curl https://prosody.im/files/prosody-debian-packages.key | gpg --dearmor > /usr/share/keyrings/prosody-keyring.gpg"
+    - name: "curl https://prosody.im/files/prosody-debian-packages.key | gpg --dearmor -o /usr/share/keyrings/prosody-keyring.gpg"
     - creates: /usr/share/keyrings/prosody-keyring.gpg
 
 prosody-repo:

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -7,7 +7,7 @@
 
 nginx-repo-key:
   cmd.run:
-    - name: "curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor > /usr/share/keyrings/nginx-archive-keyring.gpg"
+    - name: "curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg"
     - creates: /usr/share/keyrings/nginx-archive-keyring.gpg
 
 /etc/apt/sources.list.d/nginx.list:
@@ -21,7 +21,6 @@ nginx-repo-key:
 nginx:
   pkg.installed:
     - name: nginx
-    - fromrepo: deb http://nginx.org/packages/{{ grains.os | lower }} {{ grains.oscodename }} nginx
     - require:
       - pkgrepo: /etc/apt/sources.list.d/nginx.list
   service.running:

--- a/pdns-recursor/init.sls
+++ b/pdns-recursor/init.sls
@@ -4,12 +4,12 @@
 
 pdns-repo-key:
   cmd.run:
-    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/FD380FBB-keyring.gpg"
-    - creates: /usr/share/keyrings/FD380FBB-keyring.gpg
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/powerdns-keyring.gpg"
+    - creates: /usr/share/keyrings/powerdns-keyring.gpg
 
 pdns-repo:
   pkgrepo.managed:
-    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/FD380FBB-keyring.gpg] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-46 main
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/powerdns-keyring.gpg] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-46 main
     - file: /etc/apt/sources.list.d/pdns.list
     - clean_file: True
     - require:

--- a/pdns-recursor/init.sls
+++ b/pdns-recursor/init.sls
@@ -2,12 +2,18 @@
 # pdns-recursor
 #
 
+pdns-repo-key:
+  cmd.run:
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/FD380FBB-keyring.gpg"
+    - creates: /usr/share/keyrings/FD380FBB-keyring.gpg
+
 pdns-repo:
   pkgrepo.managed:
-    - name: deb [arch=amd64] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-46 main
-    - clean_file: True
-    - key_url: https://repo.powerdns.com/FD380FBB-pub.asc
+    - name: deb [arch=amd64 signed-by=/usr/share/keyrings/FD380FBB-keyring.gpg] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-46 main
     - file: /etc/apt/sources.list.d/pdns.list
+    - clean_file: True
+    - require:
+      - cmd: pdns-repo-key
 
 pdns-recursor:
   pkg.installed:

--- a/pdns-recursor/init.sls
+++ b/pdns-recursor/init.sls
@@ -4,7 +4,7 @@
 
 pdns-repo-key:
   cmd.run:
-    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor > /usr/share/keyrings/powerdns-keyring.gpg"
+    - name: "curl https://repo.powerdns.com/FD380FBB-pub.asc | gpg --dearmor -o /usr/share/keyrings/powerdns-keyring.gpg"
     - creates: /usr/share/keyrings/powerdns-keyring.gpg
 
 pdns-repo:

--- a/pdns-recursor/remove.sls
+++ b/pdns-recursor/remove.sls
@@ -6,7 +6,6 @@ pdns-repo:
   pkgrepo.managed:
     - name: deb [arch=amd64] http://repo.powerdns.com/debian {{ grains.oscodename }}-rec-42 main
     - clean_file: True
-    - key_url: https://repo.powerdns.com/FD380FBB-pub.asc
     - file: /etc/apt/sources.list.d/pdns.list
     - enabled: False
 

--- a/telegraf/init.sls
+++ b/telegraf/init.sls
@@ -16,7 +16,7 @@ influxdb-repo-key:
 influxdb-repo:
   pkgrepo.managed:
     - humanname: Jitsi Repo
-    - name: deb https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }} stable
+    - name: deb [signed-by=/usr/share/keyrings/influxdb-keyring.gpg] https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }} stable
     - file: /etc/apt/sources.list.d/influxdb.list
     - clean_file: True
     - require:

--- a/telegraf/init.sls
+++ b/telegraf/init.sls
@@ -10,7 +10,7 @@
 
 influxdb-repo-key:
   cmd.run:
-    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor > /usr/share/keyrings/influxdb-keyring.gpg"
+    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor -o /usr/share/keyrings/influxdb-keyring.gpg"
     - creates: /usr/share/keyrings/influxdb-keyring.gpg
 
 influxdb-repo:

--- a/telegraf/init.sls
+++ b/telegraf/init.sls
@@ -8,12 +8,19 @@
 {# There is data available so we think telegraf should be installed #}
 {% set role = salt['pillar.get']('netbox:role:name') %}
 
+influxdb-repo-key:
+  cmd.run:
+    - name: "curl https://repos.influxdata.com/influxdb.key | gpg --dearmor > /usr/share/keyrings/influxdb-keyring.gpg"
+    - creates: /usr/share/keyrings/influxdb-keyring.gpg
+
 influxdb-repo:
   pkgrepo.managed:
     - humanname: Jitsi Repo
     - name: deb https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }} stable
     - file: /etc/apt/sources.list.d/influxdb.list
-    - key_url: https://repos.influxdata.com/influxdb.key
+    - clean_file: True
+    - require:
+      - cmd: influxdb-repo-key
 
 telegraf:
   pkg.installed:


### PR DESCRIPTION
apt-key <repo-key> is abandoned and it is recommended to use signed-by directive for apt.
This PR changes our occurences to use this approach