### PR TITLE
Redirect HTTP requests to anycast.ffmuc.net to Doh/DoT wiki page

### DIFF
--- a/nginx/domains/apt.ffmuc.net.conf
+++ b/nginx/domains/apt.ffmuc.net.conf
@@ -7,7 +7,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name apt.ffmuc.net apt.in.ffmuc.net anycast01.ffmuc.net anycast02.ffmuc.net;
+    server_name apt.ffmuc.net apt.in.ffmuc.net;
 
     root /srv/www/apt.ffmuc.net;
     fancyindex on;
@@ -28,7 +28,7 @@ server {
     location /unstable/ {
         proxy_pass https://download.jitsi.org/unstable/;
         proxy_cache_lock on;
-		proxy_cache apt_cache; 
+        proxy_cache apt_cache;
         proxy_cache_revalidate on;
         proxy_cache_background_update on;
         proxy_cache_valid 200 1h;

--- a/nginx/domains/doh.ffmuc.net.conf
+++ b/nginx/domains/doh.ffmuc.net.conf
@@ -20,17 +20,19 @@ upstream doh-backend-v6 {
     keepalive 16;
     server [::1]:445;
 }
-    
+
 limit_req_zone $binary_remote_addr zone=doh_requests:10m rate=5000r/s;
 server {
     listen [::]:80;
     listen 80;
-    server_name doh.ffmuc.net dot.ffmuc.net;
+
+    server_name doh.ffmuc.net dot.ffmuc.net anycast.ffmuc.net anycast01.ffmuc.net anycast02.ffmuc.net;
+
     if ( $request_method !~ ^(GET|POST|HEAD)$ ) {
         return 501;
     }
     location / {
-    	return 301 https://$host$request_uri;
+        return 301 https://$host$request_uri;
     }
 
     access_log /var/log/nginx/{{ domain }}_access.log json_normal;
@@ -40,15 +42,17 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name doh.ffmuc.net dot.ffmuc.net;
+    server_name doh.ffmuc.net dot.ffmuc.net anycast.ffmuc.net anycast01.ffmuc.net anycast02.ffmuc.net;
 
     ssl_session_timeout   4h;
+
+    set $wiki_page "https://ffmuc.net/wiki/doku.php?id=knb:dohdot"
 
     if ( $request_method !~ ^(GET|POST|HEAD)$ ) {
         return 501;
     }
-    if ($host = dot.ffmuc.net) {
-	    return 301 https://ffmuc.net/wiki/doku.php?id=knb:dohdot;
+    if ($host ~ ^(dot|anycast\d*)\.ffmuc\.net$) {
+        return 301 $wiki_page;
     }
 
     location /dns-query {
@@ -66,16 +70,16 @@ server {
     #	proxy_set_header Connection "";
     }
     location / {
-    	if ( $request_method = GET ) {
-	        set $rew "1";
+        if ( $request_method = GET ) {
+            set $rew "1";
         }
         if ( $args = ""){
             set $rew "${rew}1";
         }
         if ( $rew = "11" ) {
-            return 301 https://ffmuc.net/wiki/doku.php?id=knb:dohdot;
+            return 301 $wiki_page;
         }
-    	limit_req zone=doh_requests burst=6000;
+        limit_req zone=doh_requests burst=6000;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
@@ -89,7 +93,7 @@ server {
 
     ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
-    
+
     access_log /var/log/nginx/{{ domain }}_access.log json_anonym;
     error_log /var/log/nginx/{{ domain }}_error.log;
 }


### PR DESCRIPTION
In the chat it has been proposed to show the DNS/anycast IP addresses when accessing https://anycast.ffmuc.net/ via HTTP(S).
This would help users who try to set up our DNS servers as upstreams, but unencrypted (so not dot/doh.ffmuc.net), after they see anycast.ffmuc.net mentioned somewhere (https://mobile.twitter.com/freifunkmuc/status/1378029853308506115).

Now anycast.ffmuc.net, anycast01.ffmuc.net and anycast02.ffmuc.net are handled as aliases for dot.ffmuc.net in nginx, 301-redirected to https://ffmuc.net/wiki/doku.php?id=knb:dohdot on access over HTTP.