### PR TITLE
Add missing semicolon in doh.ffmuc.net.conf

### DIFF
--- a/nginx/domains/doh.ffmuc.net.conf
+++ b/nginx/domains/doh.ffmuc.net.conf
@@ -46,7 +46,7 @@ server {
 
     ssl_session_timeout   4h;
 
-    set $wiki_page "https://ffmuc.net/wiki/doku.php?id=knb:dohdot"
+    set $wiki_page "https://ffmuc.net/wiki/doku.php?id=knb:dohdot";
 
     if ( $request_method !~ ^(GET|POST|HEAD)$ ) {
         return 501;


### PR DESCRIPTION
Small fixup of #106, forgot a semicolon :upside_down_face: 

Already made sure that this is the only error, hot-fixed it and everything went through fine, with the changes working as expected.