### PR TITLE
Gather PowerDNS Recursor stats with Telegraf

### DIFF
--- a/pdns-recursor/pdns-recursor.override.service
+++ b/pdns-recursor/pdns-recursor.override.service
@@ -19,3 +19,5 @@ ProtectKernelTunables=false
 ProtectSystem=false
 #RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictAddressFamilies=
+# Give pdns group write access to /run/pdns-recursor so Telegraf can create read sockets
+RuntimeDirectoryMode=0775

--- a/pdns-recursor/recursor.conf
+++ b/pdns-recursor/recursor.conf
@@ -15,3 +15,5 @@ threads={{ threads }}
 version-string=dot.ffmuc.net
 server-id=dot.ffmuc.net
 edns-padding-from=0.0.0.0/0
+# Allow group read/write on socket for Telegraf
+socket-mode = 660

--- a/telegraf/files/in_powerdns_recursor.conf
+++ b/telegraf/files/in_powerdns_recursor.conf
@@ -1,2 +1,6 @@
 [[inputs.powerdns_recursor]]
   unix_sockets = ["/run/pdns-recursor/pdns_recursor.controlsocket"]
+  ## Directory to create receive socket.
+  socket_dir = "/run/pdns-recursor"
+  ## Socket permissions for the receive socket.
+  socket_mode = "0666"

--- a/telegraf/init.sls
+++ b/telegraf/init.sls
@@ -51,7 +51,7 @@ systemd-reload-telegraf:
   file.absent
 {% endif %}
 
-{% if salt["service.enabled"]("pdns-recursor") and 'dnsdist' in tags and false %}{# broken #}
+{% if salt["service.enabled"]("pdns-recursor") and 'dnsdist' in tags %}
 add_telegraf_pdns_group:
   group.present:
     - name: pdns
@@ -181,7 +181,7 @@ remove_asterisk_monitoring:
           service: telegraf
 
 /etc/telegraf/telegraf.d/in-powerdns_recursor.conf:
-{% if salt["service.available"]("pdns-recursor") and false %}{# not working #}
+{% if salt["service.available"]("pdns-recursor") %}
   file.managed:
     - source: salt://telegraf/files/in_powerdns_recursor.conf
 {% else %}


### PR DESCRIPTION
This is an attempt to get PowerDNS Recursor Stats into InfluxDB and thus Grafana, using the Telegraf [input plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/powerdns_recursor).
We don't really have any insight on the recursors' health and state yet, only indirectly from dnsdist in front of them.
This basically follows the guide from the plugin README.

The only difference is that we don't create a separate directory under `/run` for the listening sockets (`socket_dir`), but reuse `/run/pdns-recursor` which systemd already creates for the recursor. Creating new directories in `/run` is ugly, because it is a virtual file system and everything's lost after reboot.
This also means we have to set the mode for `/run/pdns-recursor` to `0775` so the `pdns` _group_ has write access as well (not only the user). Thankfully all-mighty systemd gives us the option `RuntimeDirectoryMode` for this.

I have no idea whether this works like this. A few fixes might be required after a test rollout.
(I am opening the PR now because I have it ready, but won't deploy this until tomorrow. So please don't merge, unless you want to deploy yourself.)