### PR TITLE
Remove obsolete daemon-reload cmd from pdns-recursor

### DIFF
--- a/pdns-recursor/init.sls
+++ b/pdns-recursor/init.sls
@@ -32,12 +32,6 @@ systemd-resolved:
   service.dead:
     - enable: False
 
-systemd-reload-pdns-rec:
-  cmd.run:
-    - name: systemctl --system daemon-reload
-    - watch_in:
-      - service: pdns-recursor
-
 /etc/powerdns/recursor.conf:
   file.managed:
     - source: salt://pdns-recursor/recursor.conf


### PR DESCRIPTION
Follow-up to #110 

Turns out the scheduled highstate restarts all recursors every day.
I believe this is due to having removed the `onchanges` keyword from `systemd-reload-pdns-rec`, which makes it run every time now (it's just a cmd.run state). Because it has a `watch_in` on `service: pdns-recursor`, that one triggers as well, restarting the recursor.

https://github.com/freifunkMUC/ffmuc-salt-public/blob/0e4c5c7f8b2a6a1d9b0cf01350b07e9640d5bdae/pdns-recursor/init.sls#L35-L39

Because we no longer install any custom service or override.conf file we no longer need to run `daemon-control`, so let's remove it altogether.