### PR TITLE
Only keep last 14 nginx logs (per vhost)

### DIFF
--- a/nginx/files/logrotate.conf
+++ b/nginx/files/logrotate.conf
@@ -1,0 +1,4 @@
+# Override some settings from configuration included in nginx package
+/var/log/nginx/*.log {
+        rotate 14
+}

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -115,4 +115,8 @@ nginx-module-{{ module }}:
       - service: nginx
 {% endfor %}{# config #}
 
+/etc/logrotate.d/z_nginx:
+  file.managed:
+    - source: salt://nginx/files/logrotate.conf
+
 {% endif %}{# webserver in role #}


### PR DESCRIPTION
webfrontend03 keeps running low on storage every day, and only recovers midnight when logrotate runs.
Most logs come from nginx, around 12 GiB. Which in turn is mostly caused by doh.ffmuc.net.
An uncompressed log file for one day is around 3 GiB, compressed they are around 120 MiB.

By only keeping the last 14 logs instead of 525, we get rid of around  38 * 120 MiB, ~ 4-5 GiB.

Instead of maintaining our own complete logrotate config file, this just overrides the `rotate` directive in a new `/etc/logrotate.d/z_nginx` file (the prefix is so the file is ordered after the original file to make the override work).

For reference, the original file from the apt package:
`/etc/logrotate.d/nginx`
```
/var/log/nginx/*.log {
    daily
    missingok
    rotate 52
    compress
    delaycompress
    notifempty
    create 640 nginx adm
    sharedscripts
    postrotate
        if [ -f /var/run/nginx.pid ]; then
            kill -USR1 `cat /var/run/nginx.pid`
        fi
    endscript
}
```