### PR TITLE
Replace whole nginx logrotate config file

### DIFF
--- a/nginx/files/logrotate.conf
+++ b/nginx/files/logrotate.conf
@@ -1,4 +1,15 @@
-# Override some settings from configuration included in nginx package
 /var/log/nginx/*.log {
+        daily
+        missingok
         rotate 14
+        compress
+        delaycompress
+        notifempty
+        create 640 nginx adm
+        sharedscripts
+        postrotate
+                if [ -f /var/run/nginx.pid ]; then
+                        kill -USR1 `cat /var/run/nginx.pid`
+                fi
+        endscript
 }

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -115,7 +115,7 @@ nginx-module-{{ module }}:
       - service: nginx
 {% endfor %}{# config #}
 
-/etc/logrotate.d/z_nginx:
+/etc/logrotate.d/nginx:
   file.managed:
     - source: salt://nginx/files/logrotate.conf
 


### PR DESCRIPTION
Apparently, contrary to what the man page says, later files *do not* override earlier ones,
instead there is a conflict if multiple directives refer to the same log files.

```
reading config file z_nginx
error: z_nginx:2 duplicate log entry for /var/log/nginx/access.log
error: found error in file z_nginx, skipping
```

So now we manage and override the whole `/etc/logrotate.d/nginx` file instead.

Tested on webfrontend03 and there was no error anymore.