### PR TITLE
Point to Wiki page of FNMUC e.V.

### DIFF
--- a/nginx/domains/fnmuc.net.conf
+++ b/nginx/domains/fnmuc.net.conf
@@ -6,7 +6,7 @@ server {
     listen [::]:443 ssl http2;
     server_name fnmuc.net;
 
-    return 301 https://ffmuc.net/impressum/;
+    return 301 https://ffmuc.net/wiki/doku.php?id=ev:start;
 
     ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;


### PR DESCRIPTION
As discussed in the chat, it makes far more sense to point fnmuc.net to our wiki page instead of the imprint, as we can reach more supporters that way.