### PR TITLE
Serve FFMUC's freifunk.net subdomains with Bind and request LE certificates

### DIFF
--- a/_modules/ddns.py
+++ b/_modules/ddns.py
@@ -231,9 +231,9 @@ def update(
             replace = True
         # If there is no entry usual dns_update.add() happens
 
-        dns_update = dns.update.Update(
-            zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm
-        )
+    dns_update = dns.update.Update(
+        zone, keyring=keyring, keyname=keyname, keyalgorithm=keyalgorithm
+    )
     if replace:
         dns_update.replace(name, ttl, rdata)
     elif not is_exist:

--- a/_modules/netbox_vms.py
+++ b/_modules/netbox_vms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag..
-'''
+"""WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag..
+"""
 
 import requests
 import logging
@@ -10,8 +10,11 @@ log = logging.getLogger(__name__)
 
 def get_vms_by_filter(netbox_api, netbox_token, filter):
     # Example filter: 'tag=authorative-dns'
-    headers = {"Authorization": "Token {}".format(netbox_token), "Accept": "application/json"}
-    url = f'{netbox_api}/virtualization/virtual-machines/?{filter}'
+    headers = {
+        "Authorization": "Token {}".format(netbox_token),
+        "Accept": "application/json",
+    }
+    url = f"{netbox_api}/virtualization/virtual-machines/?{filter}"
     auth_servers = []
     try:
         response = requests.get(url, headers=headers)

--- a/_modules/netbox_vms.py
+++ b/_modules/netbox_vms.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+'''WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag..
+'''
+
+import requests
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def get_vms_by_filter(netbox_api, netbox_token, filter):
+    # Example filter: 'tag=authorative-dns'
+    headers = {"Authorization": "Token {}".format(netbox_token), "Accept": "application/json"}
+    url = f'{netbox_api}/virtualization/virtual-machines/?{filter}'
+    auth_servers = []
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        response = response.json()
+        log.info(response)
+        for auth in response["results"]:
+            auth_servers.append(auth["name"])
+    except Exception as e:
+        log.error(str(e))
+        __context__["retcode"] = 1
+        return e
+    return auth_servers

--- a/certs/files/cleanup-dns.sh.jinja
+++ b/certs/files/cleanup-dns.sh.jinja
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Script to nsupdate all our authoritative servers, supposed to be run by certbot.
+# Requires bind9-utils installed.
+
+# The following environment variables are passed to the script by certbot:
+# CERTBOT_DOMAIN, CERTBOT_VALIDATION, CERTBOT_TOKEN (HTTP-01 only), CERTBOT_REMAINING_CHALLENGES, CERTBOT_ALL_DOMAINS, CERTBOT_AUTH_OUTPUT
+
+HOST="_acme-challenge"
+
+{%- set update_key = salt['pillar.get']('netbox:config_context:dns_zones:update_keys:letsencrypt:key') %}
+UPDATE_KEY="{{ update_key }}"
+
+AUTH_SERVERS=("webfrontend03.ov.ffmuc.net" "webfrontend04.ov.ffmuc.net" "webfrontend05.ov.ffmuc.net" "webfrontend06.ov.ffmuc.net")
+
+for AUTH in ${AUTH_SERVERS[@]}; do
+	nsupdate -y "hmac-sha512:letsencrypt:${UPDATE_KEY}" << EOM
+server ${AUTH} 553
+zone ${CERTBOT_DOMAIN}
+update delete ${HOST}.${CERTBOT_DOMAIN} TXT "${CERTBOT_VALIDATION}"
+send
+EOM
+	echo ""
+done

--- a/certs/files/dns_plugin_credentials.ini
+++ b/certs/files/dns_plugin_credentials.ini
@@ -1,0 +1,1 @@
+dns_cloudflare_api_token = {{ cloudflare_token }}

--- a/certs/files/update-dns.sh.jinja
+++ b/certs/files/update-dns.sh.jinja
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script to nsupdate all our authoritative servers, supposed to be run by certbot.
+# Requires bind-tools installed.
+
+# The following environment variables are passed to the script by certbot:
+# CERTBOT_DOMAIN, CERTBOT_VALIDATION, CERTBOT_TOKEN (HTTP-01 only), CERTBOT_REMAINING_CHALLENGES, CERTBOT_ALL_DOMAINS
+
+HOST="_acme-challenge"
+
+{%- set update_key = salt['pillar.get']('netbox:config_context:dns_zones:update_keys:letsencrypt:key') %}
+UPDATE_KEY="{{ update_key }}"
+
+{#- TODO: use netbox_vms:get_vms_by_filter to get authoritative DNS servers
+{%- set auth_servers = salt['netbox_vms:get_vms_by_filter'](
+    salt['pillar.get']('netbox:config_context:netbox:api_url'),
+    salt['pillar.get']('netbox:config_context:dns_zones:netbox_token'),
+    'tag=authorative-dns'
+) %}
+AUTH_SERVERS=({{ auth_servers | join(" ") }})
+#}
+
+AUTH_SERVERS=("webfrontend03.ov.ffmuc.net" "webfrontend04.ov.ffmuc.net" "webfrontend05.ov.ffmuc.net" "webfrontend06.ov.ffmuc.net")
+
+for AUTH in ${AUTH_SERVERS[@]}; do
+	nsupdate -y "hmac-sha512:letsencrypt:${UPDATE_KEY}" << EOM
+server ${AUTH} 553
+zone ${CERTBOT_DOMAIN}
+{#- Don't delete existing records as they might be of other webfrontends renewing simultaneously. #}
+update add ${HOST}.${CERTBOT_DOMAIN} 5 TXT "${CERTBOT_VALIDATION}"
+send
+EOM
+	echo ""
+done

--- a/cloudflare/init.sls
+++ b/cloudflare/init.sls
@@ -6,7 +6,6 @@
 # Get all nodes for DNS records
 {% set nodes = salt['mine.get']('netbox:platform:slug:linux', 'minion_id', tgt_type='pillar') %}
 {% set cnames = salt['pillar.get']('netbox:config_context:dns_zones:cnames') %}
-{% set custom_records = salt['pillar.get']('netbox:config_context:dns_zones:custom_records', []) %}
 
 ffmuc.net:
   cloudflare.manage_zone_records:

--- a/dns-server/auth/db.x.freifunk.net.jinja
+++ b/dns-server/auth/db.x.freifunk.net.jinja
@@ -1,0 +1,19 @@
+$ORIGIN .
+$TTL 3600	; 1 week
+{{ domain }}		IN	SOA	anycast01.ffmuc.net. hostmaster.ffmuc.net. (
+					2023071001 ; serial
+					300        ; refresh (5 minutes)
+					100        ; retry (1 minute 40 seconds)
+					6000       ; expire (1 hour 40 minutes)
+					600        ; minimum (10 minutes)
+					)
+			IN	NS	anycast01.ffmuc.net.
+			IN	NS	anycast02.ffmuc.net.
+
+			IN	AAAA	2001:678:ed0:f000::
+			IN	AAAA	2001:678:e68:f000::
+
+			IN	A	5.1.66.255
+			IN	A	185.150.99.255
+
+$ORIGIN {{domain}}.

--- a/dns-server/auth/db.x.freifunk.net.jinja
+++ b/dns-server/auth/db.x.freifunk.net.jinja
@@ -16,4 +16,4 @@ $TTL 3600	; 1 week
 			IN	A	5.1.66.255
 			IN	A	185.150.99.255
 
-$ORIGIN {{domain}}.
+$ORIGIN {{ domain }}.

--- a/dns-server/auth/named.conf.local
+++ b/dns-server/auth/named.conf.local
@@ -7,6 +7,7 @@
 //include "/etc/bind/zones.rfc1918";
 {%- set update_keys = salt['pillar.get']('netbox:config_context:dns_zones:update_keys') %}
 {%- set zones = salt['pillar.get']('netbox:config_context:dns_zones:zones') %}
+{%- set freifunk_net_zones = salt['pillar.get']('netbox:config_context:dns_zones:freifunk_net_zones') %}
 
 
 {%- for zone_key in update_keys | sort %}
@@ -21,7 +22,18 @@ key "{{ zone_key }}" {
 zone "{{ zone }}" {
 	type master;
 	file "/etc/bind/zones/db.{{ zone }}";
-        update-policy  { 
+	update-policy  {
+	{%- for zone_key in update_keys | sort %}
+		grant {{ zone_key }} zonesub {{ update_keys[zone_key]['type'] }};
+	{%- endfor %}
+	};
+};
+{%- endfor %}
+{%- for zone in freifunk_net_zones %}
+zone "{{ zone }}" {
+	type master;
+	file "/etc/bind/zones/db.{{ zone }}";
+	update-policy  {
 	{%- for zone_key in update_keys | sort %}
 		grant {{ zone_key }} zonesub {{ update_keys[zone_key]['type'] }}; 
 	{%- endfor %}

--- a/nebula/files/config.yml.jinja
+++ b/nebula/files/config.yml.jinja
@@ -325,8 +325,12 @@ firewall:
   - port: 53
     proto: tcp
     host: any
+  # Bind
   - port: 553
     proto: udp
+    host: any
+  - port: 553
+    proto: tcp
     host: any
   # access pdns-recursor as dnsdist is listening on 53
   - port: 1653

--- a/nginx/domains/ffmuc.net.conf
+++ b/nginx/domains/ffmuc.net.conf
@@ -10,7 +10,7 @@ upstream wiki_upstream {
 }
 
 server {
-	listen 443 ssl http2;
+    listen 443 ssl http2;
     listen [::]:443 ssl http2;
     server_name ffmuc.net 
         www.ffmuc.net 
@@ -19,110 +19,32 @@ server {
         hp.ext.ffmuc.net
         www.freewifi.bayern freewifi.bayern 
         www.ffmuc.bayern ffmuc.bayern 
-        www.muenchen.freifunk.net muenchen.freifunk.net
-        www.münchen.freifunk.net münchen.freifunk.net
-        www.xn--mnchen-3ya.freifunk.net xn--mnchen-3ya.freifunk.net
-        www.augsburg.freifunk.net augsburg.freifunk.net
         www.freifunk-muenchen.de hp.freifunk-muenchen.de freifunk-muenchen.de
         www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net
         www.xn--freifunk-mnchen-8vb.de xn--freifunk-mnchen-8vb.de
         www.freifunk-münchen.de freifunk-münchen.de;
-    
-    # Force HTTPS connection. This rules is domain agnostic
-    if ($scheme != "https") {
-       rewrite ^ https://$host$uri permanent;
-    }
-    
-    if ( $host = wiki.ffmuc.net ) {
-       return 301 https://ffmuc.net/wiki/doku.php;
-    }
-    root /srv/www/ffmuc.net/_site/;
 
-    index index.html;
-
-    location /favicon.ico {
-        root /srv/www/ffmuc.net/_site/assets/;
-    }
-   
-    # Point SSID-URL to ffmuc.net
-    rewrite ^/(uml_.*|muc_.*|gauting|freising|augsburg|welt)$ https://ffmuc.net redirect;
-
-    location ~ ^/speed(.*)$ {
-        return 301 https://speed.ffmuc.net$1;
-    }
-
-    location /pad/ {
-        proxy_pass         http://etherpad_upstream/;
-        proxy_redirect     off;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_set_header   Upgrade $http_upgrade;
-        proxy_set_header   Connection $connection_upgrade;
-        client_max_body_size 200M;
-        proxy_http_version 1.1;
-        proxy_request_buffering off;
-    }
-  
-    location /static {
-        rewrite /static/(.*) /static/$1 break;
-        proxy_pass http://wiki_upstream/;
-        proxy_set_header Host $host;
-        proxy_buffering off;
-    }
-   
-    location /wiki/ {
-        #deny all;
-        proxy_pass         http://wiki_upstream/;
-        proxy_redirect     off;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name;
-        proxy_http_version 1.1;
-        client_max_body_size 200M;
-        proxy_request_buffering off;
-    }
-
-    location /draw/ {
-        rewrite /draw/d/(.*)/socket.io/(.*) /socket.io/$2 break;
-        rewrite /draw/d/(.*) /boards/$1 break;
-        rewrite /draw/tools/(.*) /boards/tools/$1 break;
-        proxy_pass          http://draw_upstream/;
-        proxy_ssl_server_name on;
-        proxy_set_header    Upgrade $http_upgrade;
-        proxy_set_header    Connection "upgrade";
-        proxy_set_header Host "wbo.ophir.dev";
-        proxy_ssl_name  $proxy_host;
-        proxy_buffering off;
-    }
-   
-    location /draw2 {
-        rewrite /draw2/d/(.*) /boards/$1 break;
-        proxy_pass https://wbo.ophir.dev;
-        proxy_ssl_server_name on;
-        proxy_set_header Host "wbo.ophir.dev";
-        proxy_ssl_name $proxy_host;
-        proxy_buffering off;
-    }
-
-    location /router-flashen {
-        return "https://ffmuc.net/wiki/doku.php?id=knb:flash";
-    }
-    location /map {
-        return https://map.ffmuc.net;
-    }
-
-    location /podcast/ {
-        deny all;
-    }
     ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
 
-    access_log /var/log/nginx/hp.ffmuc.net_access.log json_normal;
-    error_log /var/log/nginx/hp.ffmuc.net_error.log;
+    include sites-enabled/ffmuc.net.include;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name
+        www.muenchen.freifunk.net muenchen.freifunk.net
+        www.münchen.freifunk.net münchen.freifunk.net
+        www.xn--mnchen-3ya.freifunk.net xn--mnchen-3ya.freifunk.net
+        www.augsburg.freifunk.net augsburg.freifunk.net
+        www.wertingen.freifunk.net wertingen.freifunk.net
+        www.donau-ries.freifunk.net donau-ries.freifunk.net;
+
+    ssl_certificate     /etc/letsencrypt/live/muenchen.freifunk.net/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/muenchen.freifunk.net/privkey.pem;
+
+    include sites-enabled/ffmuc.net.include;
 }
 
 server {
@@ -143,5 +65,6 @@ server {
         www.freifunk-muenchen.net hp.freifunk-muenchen.net freifunk-muenchen.net
         www.xn--freifunk-mnchen-8vb.de xn--freifunk-mnchen-8vb.de
         www.freifunk-münchen.de freifunk-münchen.de;
+
     return 301 https://$host$request_uri;
 }

--- a/nginx/domains/ffmuc.net.include
+++ b/nginx/domains/ffmuc.net.include
@@ -1,0 +1,93 @@
+# Force HTTPS connection. This rules is domain agnostic
+if ($scheme != "https") {
+	rewrite ^ https://$host$uri permanent;
+}
+
+if ( $host = wiki.ffmuc.net ) {
+	return 301 https://ffmuc.net/wiki/doku.php;
+}
+root /srv/www/ffmuc.net/_site/;
+
+index index.html;
+
+location /favicon.ico {
+	root /srv/www/ffmuc.net/_site/assets/;
+}
+
+# Point SSID-URL to ffmuc.net
+rewrite ^/(uml_.*|muc_.*|gauting|freising|augsburg|welt)$ https://ffmuc.net redirect;
+
+location ~ ^/speed(.*)$ {
+	return 301 https://speed.ffmuc.net$1;
+}
+
+location /pad/ {
+	proxy_pass         http://etherpad_upstream/;
+	proxy_redirect     off;
+	proxy_set_header   Host $host;
+	proxy_set_header   X-Real-IP $remote_addr;
+	proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header   X-Forwarded-Host $server_name;
+	proxy_set_header   X-Forwarded-Proto $scheme;
+	proxy_set_header   Upgrade $http_upgrade;
+	proxy_set_header   Connection $connection_upgrade;
+	client_max_body_size 200M;
+	proxy_http_version 1.1;
+	proxy_request_buffering off;
+}
+
+location /static {
+	rewrite /static/(.*) /static/$1 break;
+	proxy_pass http://wiki_upstream/;
+	proxy_set_header Host $host;
+	proxy_buffering off;
+}
+
+location /wiki/ {
+#deny all;
+	proxy_pass         http://wiki_upstream/;
+	proxy_redirect     off;
+	proxy_set_header   Host $host;
+	proxy_set_header   X-Real-IP $remote_addr;
+	proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+	proxy_set_header   X-Forwarded-Host $server_name;
+	proxy_http_version 1.1;
+	client_max_body_size 200M;
+	proxy_request_buffering off;
+}
+
+location /draw/ {
+	rewrite /draw/d/(.*)/socket.io/(.*) /socket.io/$2 break;
+	rewrite /draw/d/(.*) /boards/$1 break;
+	rewrite /draw/tools/(.*) /boards/tools/$1 break;
+	proxy_pass          http://draw_upstream/;
+	proxy_ssl_server_name on;
+	proxy_set_header    Upgrade $http_upgrade;
+	proxy_set_header    Connection "upgrade";
+	proxy_set_header Host "wbo.ophir.dev";
+	proxy_ssl_name  $proxy_host;
+	proxy_buffering off;
+}
+
+location /draw2 {
+	rewrite /draw2/d/(.*) /boards/$1 break;
+	proxy_pass https://wbo.ophir.dev;
+	proxy_ssl_server_name on;
+	proxy_set_header Host "wbo.ophir.dev";
+	proxy_ssl_name $proxy_host;
+	proxy_buffering off;
+}
+
+location /router-flashen {
+	return "https://ffmuc.net/wiki/doku.php?id=knb:flash";
+}
+location /map {
+	return https://map.ffmuc.net;
+}
+
+location /podcast/ {
+	deny all;
+}
+
+access_log /var/log/nginx/hp.ffmuc.net_access.log json_normal;
+error_log /var/log/nginx/hp.ffmuc.net_error.log;

--- a/nginx/files/nginx.conf.jinja
+++ b/nginx/files/nginx.conf.jinja
@@ -94,7 +94,7 @@ http {
 	# Virtual Host Configs
 	##
 	include /etc/nginx/conf.d/*.conf;
-	include /etc/nginx/sites-enabled/*;
+	include /etc/nginx/sites-enabled/*.conf;
 
 	##
 	# Logging Settings

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -115,6 +115,16 @@ nginx-module-{{ module }}:
       - service: nginx
 {% endfor %}{# config #}
 
+/etc/nginx/sites-enabled/ffmuc.net.include:
+  file.managed:
+    - source: salt://nginx/domains/ffmuc.net.include
+    - makedirs: True
+    - template: jinja
+    - require:
+      - pkg: nginx
+    - require_in:
+      - service: nginx
+
 /etc/logrotate.d/nginx:
   file.managed:
     - source: salt://nginx/files/logrotate.conf


### PR DESCRIPTION
This is already live on our systems and the commit already part of the main branch of the local salt repo on docker05.

This PR is for completeness sake and to ask for improvement suggestions, which we can apply in future commits.

Thanks a lot to @GoliathLabs who did this together with me.

---

* Add the following zones to our authoriative servers:
  - muenchen.freifunk.net
  - münchen.freifunk.net
  - augsburg.freifunk.net (not delegated by freifunk.net yet)
  - wertingen.freifunk.net
  - donau-ries.freifunk.net
* Forward DNS requests for these domains to the auth servers in dnsdist
* Set up certbot for a second certificate which includes above mentioned domains (except augsburg.freifunk.net for now).
  We use the DNS-01 ACME challenge, interfacing with our own auth servers using DDNS.
  This is implemented using a cmd.run state as Salt's `acme` module interface doesn't support custom actions.
* Restructure nginx config for ffmuc.net to handle these additional domains with a separate certificate.

---

TODOs:
* Get the list of authoritative nameservers for the ddns update script from netbox (hardcoded right now)
* At least find a way that the certbot run only reports changes when it actually received a new cert from LE
* Ideally get the `acme` module extended to support the "manual unsupervised" mode
* Extend the `ddns` module to support two records of the same type, so that we can specify the AAAA & A records the same way as all the other records (right now they can't easily be changed, changes to the zone files do not get read by Bind, even after restarts).