### PR TITLE
Add augsburg.freifunk.net to freifunk.net cert

### DIFF
--- a/certs/init.sls
+++ b/certs/init.sls
@@ -211,7 +211,7 @@ muenchen.freifunk.net-wildcard-cert:
         -d "xn--mnchen-3ya.freifunk.net" -d "*.xn--mnchen-3ya.freifunk.net"
         -d "wertingen.freifunk.net" -d "*.wertingen.freifunk.net"
         -d "donau-ries.freifunk.net" -d "*.donau-ries.freifunk.net"
-{#-        -d "augsburg.freifunk.net" -d "*.augsburg.freifunk.net" #}
+        -d "augsburg.freifunk.net" -d "*.augsburg.freifunk.net"
     - require:
         - cmd: certbot
         - pip: acme-client


### PR DESCRIPTION
The freifunk.net admins have delegated augsburg.freifunk.net to our nameservers.

```
$ dig NS augsburg.freifunk.net

;; ANSWER SECTION:
augsburg.freifunk.net.  7200    IN      NS      anycast01.ffmuc.net.
augsburg.freifunk.net.  7200    IN      NS      anycast02.ffmuc.net.
```

We are maintaining three records for the old Augsburg team for their mail server:
```
augsburg.freifunk.net.      60 IN      MX      10 mail.augsburg.freifunk.net.
mail.augsburg.freifunk.net. 60 IN      AAAA    2a01:4f8:120:8004::2
mail.augsburg.freifunk.net. 60 IN      A       78.46.94.199
```

Now we can add it to the cert for muenchen.freifunk.net et al.

---

Already tried, works well: https://augsburg.freifunk.net/