### PR TITLE
Reduce snmpd logging level

### DIFF
--- a/snmpd/snmpd.service
+++ b/snmpd/snmpd.service
@@ -8,7 +8,7 @@ Environment="MIBSDIR=/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/s
 Environment="MIBS="
 Type=simple
 ExecStartPre=/bin/mkdir -p /var/run/agentx
-ExecStart=/usr/sbin/snmpd -Lsd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f
+ExecStart=/usr/sbin/snmpd -LSwd -Lf /dev/null -u Debian-snmp -g Debian-snmp -I -smux,mteTrigger,mteTriggerConf -f
 ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]


### PR DESCRIPTION
snmpd logs a ton (~180) of lines every 5 minutes on every VM when librenms collects the data like this `Connection from UDP: ... ->...`

We don't need this information, it just causes unnecessary load especially for Graylog.

Let's lower the logging level from the default NOTICE to WARNING for snmpd, which excludes these messages.
See https://serverfault.com/a/310741

Tested on docker06 to make sure this does actually work with the version we have running.