### PR TITLE
github workflows: update actions to latest version

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,8 +9,8 @@ jobs:
   black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - uses: psf/black@main
         with:
           # yamllint disable-line rule:line-length

--- a/.github/workflows/salt-lint.yml
+++ b/.github/workflows/salt-lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Salt Lint
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Run salt-lint
         uses: roaldnefs/salt-lint-action@master
         env:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,11 +18,11 @@ jobs:
     name: runner / shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: shellcheck
         # Make sure the action is pinned to a commit, as all reviewdog repos
         # have hundreds of contributors with write access (breaks easy/often)
-        uses: reviewdog/action-shellcheck@50e5e1e2284575f23a1e409d9c0804cdfc4f6e31  # v1.18.1
+        uses: reviewdog/action-shellcheck@96fa305c16b0f9cc9b093af22dcd09de1c8f1c2d  # v1.19.0
         with:
           filter_mode: "file"
           fail_on_error: true

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -7,7 +7,7 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
         with:


### PR DESCRIPTION
This silence deprecation warnings about node12 from action/checkout@v2