### PR TITLE
Fix respondd site prefixes on gateways

### DIFF
--- a/respondd/alias.json
+++ b/respondd/alias.json
@@ -8,7 +8,7 @@
       "contact": "hilfe@ffmuc.net"
     },
     "system": {
-      "domain_code": "ffmuc_{{ site }}",
+      "domain_code": "{{ prefix }}_{{ site }}",
       "role": "gateway"
     },
     "pages": [

--- a/respondd/init.sls
+++ b/respondd/init.sls
@@ -10,7 +10,9 @@
 python3-netifaces:
    pkg.installed
 
-{% for site in salt['pillar.get']('netbox:config_context:sites').values()|sum(start=[])  %}
+{% set sites = salt['pillar.get']('netbox:config_context:sites') %}
+{% for prefix, domains in sites.items() %}
+{% for site in domains %}
 
 {% if not salt['file.directory_exists']('/opt/respondd-' ~ site ) %}
 /opt/respondd-{{ site }}:
@@ -64,4 +66,4 @@ respondd@{{ site }}:
       - file: /opt/respondd-{{ site }}/config.json
       - file: /etc/systemd/system/respondd@.service
 {% endfor %}
-
+{% endfor %}


### PR DESCRIPTION
This is a follow-up to 227090309a9931d133afee8a2fc4f1fd37a91f83, making respondd on our gateways return the correct site prefix for the new Wertingen and Donau-Ries sites.