### PR TITLE
nginx: update bitte-router-erneuern link for 8/64

### DIFF
--- a/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
+++ b/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
@@ -6,7 +6,7 @@ server {
     listen [::]:443 ssl http2;
     server_name bitte-router-erneuern.ffmuc.net;
 
-    return 301 https://ffmuc.net/freifunkmuc/2019/07/11/austausch-aelterer-geraete/;
+    return 301 https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/;
 
     ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;


### PR DESCRIPTION
As we will have to drop support for 8/64 devices as well, updating this link in case someone clicks on their router on the map.