### PR TITLE
Deploy wgkex on workers in a venv

### DIFF
--- a/wgkex/init.sls
+++ b/wgkex/init.sls
@@ -1,13 +1,27 @@
 {%- if 'nextgen-gateway' in salt['pillar.get']('netbox:role:name') %}
 
-python3-pyroute2:
+python3-virtualenv:
   pkg.installed
 
 /srv/wgkex:
+  file.directory:
+    - mode: "0755"
+    - user: wgkex
+    - group: wgkex
+
+/srv/wgkex/wgkex:
   git.latest:
-    - name: https://github.com/freifunkMUC/wgkex
-    - target: /srv/wgkex
+    - name: https://github.com/freifunkMUC/wgkex.git
     - rev: main
+    - target: /srv/wgkex/wgkex
+    - user: wgkex
+
+/srv/wgkex/wgkex/venv:
+  virtualenv.managed:
+    - name: /srv/wgkex/wgkex/venv
+    - requirements: /srv/wgkex/wgkex/requirements.txt
+    - user: wgkex
+
 /etc/systemd/system/wgkex.service:
   file.managed:
     - source: salt://wgkex/wgkex.service
@@ -15,7 +29,6 @@ python3-pyroute2:
 /etc/wgkex.yaml:
   file.managed:
     - source: salt://wgkex/wgkex.yaml
-
 
 wgkex-service:
   service.running:
@@ -25,13 +38,5 @@ wgkex-service:
         - file: /etc/wgkex.yaml
     - watch:
         - file: /etc/wgkex.yaml
-
-systemd-reload-wgkex:
-  cmd.run:
-    - name: systemctl --system daemon-reload
-    - onchanges:
-      - file: /etc/systemd/system/wgkex.service
-    - watch_in:
-      - service: wgkex-service
 
 {% endif %}

--- a/wgkex/wgkex.service
+++ b/wgkex/wgkex.service
@@ -5,8 +5,8 @@ After=network-online.target
 
 [Service]
 User=wgkex
-WorkingDirectory=/srv/wgkex
-ExecStart=/usr/bin/python3 -u -m wgkex.worker.app
+WorkingDirectory=/srv/wgkex/wgkex
+ExecStart=/srv/wgkex/wgkex/venv/bin/python3 -u -m wgkex.worker.app
 Restart=on-failure
 
 # Enable Logging


### PR DESCRIPTION
Long story short, we ran into a bug in an outdated Python dependency (pyroute2 0.5.9) installed through apt. (see below for precise exception)

Let's decouple the wgkex worker installation a bit, by installing it in a venv, and install the dependencies as specified in the `requirements.txt`, because those versions are the ones the wgkex CI tests against.
This will probably be especially important when we merge and deploy the wgkex loadbalancing PR.

We might want to consider splitting the `requirements.txt` for wgkex between broker and worker, so you don't have to install unneeded packages from the respective other; but this needs to be done over there.

Another suggestion was to build a static binary using Bazel and deploy that one, which we can also look into (but I'm currently fighting myself with Bazel to get it to run on newer systems with newer Python and Pip versions...), but for now I'm going with this.

---

```
2023-12-19 22:30:56,027,27 WARNING  [__init__.py:1489] decoding WGPEER_A_ENDPOINT
2023-12-19 22:30:56,028,28 WARNING  [__init__.py:1490] Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/__init__.py", line 1486, in try_to_decode
    cell.decode()
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/generic/wireguard.py", line 175, in decode
    self['addr'] = inet_ntoa(AF_INET6, self['addr6'])
TypeError: inet_ntoa() takes exactly 1 argument (2 given)
2023-12-19 22:30:56,036,36 WARNING  [__init__.py:1489] decoding WGPEER_A_ENDPOINT
2023-12-19 22:30:56,037,37 WARNING  [__init__.py:1490] Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/__init__.py", line 1486, in try_to_decode
    cell.decode()
  File "/usr/lib/python3/dist-packages/pyroute2/netlink/generic/wireguard.py", line 175, in decode
    self['addr'] = inet_ntoa(AF_INET6, self['addr6'])
TypeError: inet_ntoa() takes exactly 1 argument (2 given)
```
(Fixed in https://github.com/svinota/pyroute2/pull/882 and/or https://github.com/svinota/pyroute2/commit/877435ba64ededcb45984a50db7ed0c121089b05)