### PR TITLE
Upgrade to Salt 3006

### DIFF
--- a/_modules/ddns.py
+++ b/_modules/ddns.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Support for RFC 2136 dynamic DNS updates.
 
@@ -23,7 +22,6 @@ Support for RFC 2136 dynamic DNS updates.
 
         {"keyname.": "keycontent"}
 """
-from __future__ import absolute_import, print_function, unicode_literals
 
 # Import python libs
 import logging
@@ -41,7 +39,6 @@ except ImportError as e:
 
 import salt.utils.files
 import salt.utils.json
-from salt.ext import six
 
 
 def __virtual__():
@@ -66,7 +63,7 @@ def _config(name, key=None, **kwargs):
     if name in kwargs:
         value = kwargs[name]
     else:
-        value = __salt__["config.option"]("ddns.{0}".format(key))
+        value = __salt__["config.option"]("ddns.{}".format(key))
         if not value:
             value = None
     return value
@@ -104,7 +101,7 @@ def add_host(
     if res is False:
         return False
 
-    fqdn = "{0}.{1}.".format(name, zone)
+    fqdn = "{}.{}.".format(name, zone)
     parts = ip.split(".")[::-1]
     popped = []
 
@@ -112,7 +109,7 @@ def add_host(
     while len(parts) > 1:
         p = parts.pop(0)
         popped.append(p)
-        zone = "{0}.{1}".format(".".join(parts), "in-addr.arpa.")
+        zone = "{}.{}".format(".".join(parts), "in-addr.arpa.")
         name = ".".join(popped)
         ptr = update(
             zone, name, ttl, "PTR", fqdn, nameserver, timeout, replace, port, **kwargs
@@ -134,7 +131,7 @@ def delete_host(zone, name, nameserver="127.0.0.1", timeout=5, port=53, **kwargs
 
         salt ns1 ddns.delete_host example.com host1
     """
-    fqdn = "{0}.{1}".format(name, zone)
+    fqdn = "{}.{}".format(name, zone)
     request = dns.message.make_query(fqdn, "A")
     answer = dns.query.udp(request, nameserver, timeout, port)
     try:
@@ -155,7 +152,7 @@ def delete_host(zone, name, nameserver="127.0.0.1", timeout=5, port=53, **kwargs
         while len(parts) > 1:
             p = parts.pop(0)
             popped.append(p)
-            zone = "{0}.{1}".format(".".join(parts), "in-addr.arpa.")
+            zone = "{}.{}".format(".".join(parts), "in-addr.arpa.")
             name = ".".join(popped)
             ptr = delete(
                 zone,
@@ -197,12 +194,12 @@ def update(
 
         salt ns1 ddns.update example.com host1 60 A 10.0.0.1
     """
-    name = six.text_type(name)
+    name = str(name)
 
     if name[-1:] == ".":
         fqdn = name
     else:
-        fqdn = "{0}.{1}".format(name, zone)
+        fqdn = "{}.{}".format(name, zone)
 
     request = dns.message.make_query(fqdn, rdtype)
     answer = dns.query.udp(request, nameserver, timeout, port)
@@ -265,12 +262,12 @@ def delete(
 
         salt ns1 ddns.delete example.com host1 A
     """
-    name = six.text_type(name)
+    name = str(name)
 
     if name[-1:] == ".":
         fqdn = name
     else:
-        fqdn = "{0}.{1}".format(name, zone)
+        fqdn = "{}.{}".format(name, zone)
 
     request = dns.message.make_query(fqdn, (rdtype or "ANY"))
     answer = dns.query.udp(request, nameserver, timeout, port)

--- a/_pillar/netbox.py
+++ b/_pillar/netbox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 A module that adds data to the Pillar structure from a NetBox API.
 
@@ -48,17 +47,12 @@ site_prefixes: ``True``
     Whether should retrieve the prefixes of the site the device belongs to.
 """
 
-from __future__ import absolute_import, print_function, unicode_literals
 import logging
-import six
 
 # Import Salt libs
 import salt.utils.http
 
-if six.PY3:
-    import ipaddress
-else:
-    import salt.ext.ipaddress as ipaddress
+import ipaddress
 
 log = logging.getLogger(__name__)
 

--- a/apt/init.sls
+++ b/apt/init.sls
@@ -21,22 +21,22 @@ salt-repo-key:
   file.managed:
     - name: /usr/share/keyrings/salt-archive-keyring.gpg
     {% if 'Ubuntu' in grains.lsb_distrib_id %}
-    - source: https://repo.saltproject.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg
+    - source: https://repo.saltproject.io/salt/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg
     {% elif 'Raspbian' in grains.lsb_distrib_id %}
-    - source: http://repo.saltproject.io/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg
+    - source: http://repo.saltproject.io/salt/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg
     {% else %}
-    - source: http://repo.saltproject.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest/salt-archive-keyring.gpg # noqa: 204
+    - source: http://repo.saltproject.io/salt/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/SALT-PROJECT-GPG-PUBKEY-2023.gpg
     {% endif %}
     - skip_verify: True
 
 salt-repo:
   pkgrepo.managed:
     {% if 'Ubuntu' in grains.lsb_distrib_id %}
-    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/salt/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
     {% elif 'Raspbian' in grains.lsb_distrib_id %}
-    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/salt/py3/debian/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main
     {% else %}
-    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main # noqa: 204
+    - name: deb [arch={{ grains.osarch }} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg] http://repo.saltproject.io/salt/py3/{{ grains.lsb_distrib_id | lower }}/{{ grains.osmajorrelease }}/{{ grains.osarch }}/latest {{ grains.oscodename }} main # noqa: 204
     {% endif %}
     - file: /etc/apt/sources.list.d/saltstack.list
     - clean_file: True

--- a/dhcp-server/init.sls
+++ b/dhcp-server/init.sls
@@ -3,12 +3,13 @@
 #
 
 # salt started complaining as this key is present in another formula...
-python3-netifaces-dhcp:
-  pkg.installed:
-    - name: python3-netifaces
+netifaces-dhcp:
+  pip.installed:  # Install into Salt's Python environment
+    - name: netifaces
 
-python3-netaddr:
-  pkg.installed
+netaddr-dhcp:
+  pip.installed:  # Install into Salt's Python environment
+    - name: netaddr
 
 isc-dhcp-server:
   pkg.installed:
@@ -43,8 +44,8 @@ dhcpd-pools:
     - template: jinja
     - require:
       - file: /etc/systemd/system/isc-dhcp-server.service
-      - pkg: python3-netifaces-dhcp
-      - pkg: python3-netaddr
+      - pip: netifaces-dhcp
+      - pip: netaddr-dhcp
     - watch_in:
       - service: isc-dhcp-server
 

--- a/dns-server/auth/init.sls
+++ b/dns-server/auth/init.sls
@@ -18,10 +18,6 @@
 include:
   - dns-server
 
-python-dnspython:
-  pkg.installed:
-    - name: python3-dnspython
-
 # Bind options
 /etc/bind/named.conf.options:
   file.managed:
@@ -166,7 +162,7 @@ record-A-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
 record-PTR-{{ node_id }}:
@@ -182,7 +178,7 @@ record-PTR-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
   {% endif %}
@@ -201,7 +197,7 @@ record-AAAA-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
 record-PTR6-{{ node_id }}:
@@ -217,7 +213,7 @@ record-PTR6-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
   {%- endif %}
@@ -237,7 +233,7 @@ record-A-overlay-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
   {% endif %}
 
@@ -258,7 +254,7 @@ record-A-external-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
   {%- endif -%}
 
@@ -278,7 +274,7 @@ record-AAAA-external-{{ node_id }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
   {%- endif %}
@@ -325,7 +321,7 @@ record-CNAME-{{ cname }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
 # we create a cname ov.ffmuc.net entry for each in.ffmuc.net entry
@@ -347,7 +343,7 @@ record-CNAME-{{ cname_ov }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
   {% endif %}
 
@@ -376,7 +372,7 @@ record-A-extra-{{ dns_entry }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 
   {%- endif %}
@@ -395,7 +391,7 @@ record-AAAA-extra-{{ dns_entry }}:
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
   {%- endif %}
 
@@ -417,7 +413,7 @@ record-{{ loop.index }}-{{ record.get('type') }}-{{ record.get('name') }}.{{ rec
     - keyalgorithm: hmac-sha512
     - replace_on_change: True
     - require:
-      - pkg: python-dnspython
+      - pip: dnspython
       - file: dns-key
 {%- endfor %}{# for record in custom_records #}
 

--- a/dns-server/init.sls
+++ b/dns-server/init.sls
@@ -12,10 +12,12 @@ bind9:
 dns_pkgs:
   pkg.installed:
     - pkgs:
-      - python3-dnspython
-      - python-dnspython
       - dnsutils
       - bind9-dnsutils
+
+dnspython:
+  pip.installed:  # Install into Salt's Python environment
+    - reload_modules: True
 
 # Reload command
 rndc-reload:

--- a/duplicity/init.sls
+++ b/duplicity/init.sls
@@ -22,6 +22,7 @@ duplicity_repo:
 
 b2sdk:
   pip.installed:
+    - pip_bin: /usr/bin/pip3  # Required with Salt Onedir packaging, otherwise dependency is installed into Salt's custom Python environment
     - require:
       - pkg: duplicity-packages
 {% endif %}

--- a/ff_base/init.sls
+++ b/ff_base/init.sls
@@ -21,7 +21,6 @@ ffmuc_packages:
       - sysstat
       - dnsutils
       - curl
-      - iftop
       - iptraf
       - speedtest-cli
       - dmidecode

--- a/icinga2/services/base-services.conf
+++ b/icinga2/services/base-services.conf
@@ -34,7 +34,8 @@ apply Service "salt-minion" {
 
 	vars.procs_critical = "1:"
 	vars.procs_warning = "1:"
-	vars.procs_command = "salt-minion"
+#	vars.procs_command = "python3.10"
+	vars.procs_argument = "salt-minion" # salt-minion 3006+ starts salt-minion as argument to the python3.10 command
 	check_interval = 2m
 	max_check_attempts = 3
 	retry_interval = 1m

--- a/wireguard/init.sls
+++ b/wireguard/init.sls
@@ -1,9 +1,9 @@
 {% set interfaces = salt['pillar.get']('netbox:interfaces') %}
-python3-netifaces:
-  pkg.installed
+netifaces:
+  pip.installed  # Install into Salt's Python environment
 
-python3-netaddr:
-  pkg.installed
+netaddr:
+  pip.installed  # Install into Salt's Python environment
 
 iptables-persistent:
   pkg.installed


### PR DESCRIPTION
This commit includes adjustments that were needed after upgrading Salt to [3006.6](https://docs.saltproject.io/en/latest/topics/releases/3006.0.html).

Most changes have been caused by the move to the "Onedir packaging" (https://docs.saltproject.io/salt/install-guide/en/latest/topics/upgrade-to-onedir.html)

---

Most prominently, the `six` dependency is no longer bundled in `salt.ext`. Since we are not using Python 2 anymore, I have run `pyupgrade` on `netbox.py` and `ddns.py`, as upstream did as well:
- https://github.com/saltstack/salt/issues/63874
- https://github.com/saltstack/salt/commit/d9b50659b2be467f31d59245e70202fbabc83092#diff-3e81c988bb0fa260da8fdbee3b44dd7b1f9ccebf488117b5f68c2f728bd9d287

Additionally, the Salt APT repository paths have changed, and the 3006 release is only available in the new ones.

Thirdly, with the move to Onedir, Salt brings its own Python environment. This affects us in two areas:
1) Python packages installed by a plain `pip.installed` are only installed to this environment and not visible to other Python applications on the system
2) Python packages installed on the system, e.g. with the system pip or as apt packages, are not visible to Salt.

This means that I had to change packages needed by Salt (e.g. to render templates) from `pkg.installed` to `pip.installed`, and for packages needed by applications I added `- pip_bin: /usr/bin/pip3` as recommended in the upgrade guide.