### PR TITLE
Fix Jitsi App Links

### DIFF
--- a/jitsi/meet/domain-config.js.jinja
+++ b/jitsi/meet/domain-config.js.jinja
@@ -1057,47 +1057,47 @@ var config = {
             appName: 'Freifunk Muenchen Jitsi Meet'
         }
 
-    //     // If true, any checks to handoff to another application will be prevented
-    //     // and instead the app will continue to display in the current browser.
-    //     disabled: false,
+        // If true, any checks to handoff to another application will be prevented
+        // and instead the app will continue to display in the current browser.
+        disabled: false,
 
-    //     // whether to hide the logo on the deep linking pages.
-    //     hideLogo: false,
+        // whether to hide the logo on the deep linking pages.
+        hideLogo: false,
 
-    //     // The ios deeplinking config.
-    //     ios: {
-    //         appName: 'Jitsi Meet',
-    //         // Specify mobile app scheme for opening the app from the mobile browser.
-    //         appScheme: 'org.jitsi.meet',
-    //         // Custom URL for downloading ios mobile app.
-    //         downloadLink: 'https://itunes.apple.com/us/app/jitsi-meet/id1165103905',
-    //         dynamicLink: {
-    //             apn: 'org.jitsi.meet',
-    //             appCode: 'w2atb',
-    //             customDomain: undefined,
-    //             ibi: 'com.atlassian.JitsiMeet.ios',
-    //             isi: '1165103905'
-    //         }
-    //     },
+        // The ios deeplinking config.
+        ios: {
+            appName: 'Jitsi Meet',
+            // Specify mobile app scheme for opening the app from the mobile browser.
+            appScheme: 'org.jitsi.meet',
+            // Custom URL for downloading ios mobile app.
+            downloadLink: 'https://itunes.apple.com/us/app/jitsi-meet/id1165103905',
+            dynamicLink: {
+                apn: 'org.jitsi.meet',
+                appCode: 'w2atb',
+                customDomain: undefined,
+                ibi: 'com.atlassian.JitsiMeet.ios',
+                isi: '1165103905'
+            }
+        },
 
-    //     // The android deeplinking config.
-    //     android: {
-    //         appName: 'Jitsi Meet',
-    //         // Specify mobile app scheme for opening the app from the mobile browser.
-    //         appScheme: 'org.jitsi.meet',
-    //         // Custom URL for downloading android mobile app.
-    //         downloadLink: 'https://play.google.com/store/apps/details?id=org.jitsi.meet',
-    //         // Android app package name.
-    //         appPackage: 'org.jitsi.meet',
-    //         fDroidUrl: 'https://f-droid.org/en/packages/org.jitsi.meet/',
-    //         dynamicLink: {
-    //             apn: 'org.jitsi.meet',
-    //             appCode: 'w2atb',
-    //             customDomain: undefined,
-    //             ibi: 'com.atlassian.JitsiMeet.ios',
-    //             isi: '1165103905'
-    //         }
-    //     }
+        // The android deeplinking config.
+        android: {
+            appName: 'Jitsi Meet',
+            // Specify mobile app scheme for opening the app from the mobile browser.
+            appScheme: 'org.jitsi.meet',
+            // Custom URL for downloading android mobile app.
+            downloadLink: 'https://play.google.com/store/apps/details?id=org.jitsi.meet',
+            // Android app package name.
+            appPackage: 'org.jitsi.meet',
+            fDroidUrl: 'https://f-droid.org/en/packages/org.jitsi.meet/',
+            dynamicLink: {
+                apn: 'org.jitsi.meet',
+                appCode: 'w2atb',
+                customDomain: undefined,
+                ibi: 'com.atlassian.JitsiMeet.ios',
+                isi: '1165103905'
+            }
+        }
     },
 
     // A property to disable the right click context menu for localVideo


### PR DESCRIPTION
This change fixes the app links (Join, Download etc.) for meet.ffmuc.net

Tested with Google Chrome Local Overrides:
![ffmeet_fix_app_urls](https://github.com/freifunkMUC/ffmuc-salt-public/assets/402304/850bb3e8-b261-413b-bcaf-7603baf45b77)
