### PR TITLE
Fix wgkex worker things

### DIFF
--- a/wgkex/init.sls
+++ b/wgkex/init.sls
@@ -15,12 +15,14 @@ python3-virtualenv:
     - rev: main
     - target: /srv/wgkex/wgkex
     - user: wgkex
+    - force_reset: True
 
 /srv/wgkex/wgkex/venv:
   virtualenv.managed:
     - name: /srv/wgkex/wgkex/venv
     - requirements: /srv/wgkex/wgkex/requirements.txt
     - user: wgkex
+    - runas: wgkex  {# workaround for https://github.com/saltstack/salt/issues/59088 #}
 
 /etc/systemd/system/wgkex.service:
   file.managed:
@@ -28,7 +30,8 @@ python3-virtualenv:
 
 /etc/wgkex.yaml:
   file.managed:
-    - source: salt://wgkex/wgkex.yaml
+    - source: salt://wgkex/wgkex.yaml.jinja
+    - template: jinja
 
 wgkex-service:
   service.running:
@@ -36,7 +39,9 @@ wgkex-service:
     - enable: True
     - require:
         - file: /etc/wgkex.yaml
+        - git: /srv/wgkex/wgkex
     - watch:
         - file: /etc/wgkex.yaml
+        - git: /srv/wgkex/wgkex
 
 {% endif %}

--- a/wgkex/wgkex.yaml.jinja
+++ b/wgkex/wgkex.yaml.jinja
@@ -1,5 +1,6 @@
 ---
 
+# [broker, worker] The domains that should be accepted by clients and for which matching WireGuard interfaces exist
 domains:
   - ffmuc_augsburg
   - ffmuc_freising
@@ -19,6 +20,15 @@ domains:
   - ffdon_sued
   - ffwert_city
   - ffwert_events
+# [broker, worker] The prefix is trimmed from the domain name and replaced with 'wg-' and 'vx-'
+# to calculate the WireGuard and VXLAN interface names
+domain_prefixes:
+  - ffmuc_
+  - ffdon_
+  - ffwert_
+# [worker] The external hostname of this worker
+externalName: {{ grains['id'] | regex_replace('in\.ffmuc\.net','ext.ffmuc.net') }}
+# [broker, worker] MQTT connection informations
 mqtt:
   broker_url: broker.ov.ffmuc.net
   username:
@@ -26,10 +36,6 @@ mqtt:
   tls: False
   broker_port: 1883
   keepalive: 20
-domain_prefixes:
-  - ffmuc_
-  - ffdon_
-  - ffwert_
 logging_config:
   formatters:
     standard:


### PR DESCRIPTION
This fixes a few things with wgkex:

- A workaround for https://github.com/saltstack/salt/issues/59088, which caused some of the (site-packages) files in the wgkex venv to be owned by root and not the specified wgkex user
- Adding `- force_reset: True` to the git state, so that it always resets to the specified reference, even if it's not a fast-forward pull
- Set the `externalName` in the wgkex config (needed for https://github.com/freifunkMUC/wgkex/pull/87)