### PR TITLE
dnsdist: set backend server selection policy to chashed to optimize cache usage

### DIFF
--- a/dnsdist/dnsdist.conf.j2
+++ b/dnsdist/dnsdist.conf.j2
@@ -77,21 +77,21 @@ end
 setRingBuffersSize(100000)
 
 {%- if 'muc01' in salt['pillar.get']('netbox:site:slug') %}
-newServer({address="10.8.0.39:1653", name="web05", weight=3, retries=2, id="7cd4655e-071e-4a9a-9623-834ba49ea472", sockets=6})
-newServer({address="10.8.0.40:1653", name="web06", weight=3, retries=2, id="d5d0a3a9-6787-479f-ad0f-106d4618ccc2", sockets=6})
-newServer({address="10.8.0.38:1653", name="gw06", weight=3, retries=2, id="42c4bdfe-0ccc-4e9e-8816-7f88421b50f8", sockets=6})
-newServer({address="10.8.0.13:1653", name="gw07", weight=3, retries=2, id="1c961f33-3a09-4b40-ae9d-5b5a8dd71061", sockets=6})
+newServer({address="10.8.0.39:1653", name="web05", weight=500, retries=2, id="7cd4655e-071e-4a9a-9623-834ba49ea472", sockets=6})
+newServer({address="10.8.0.40:1653", name="web06", weight=500, retries=2, id="d5d0a3a9-6787-479f-ad0f-106d4618ccc2", sockets=6})
+newServer({address="10.8.0.38:1653", name="gw06", weight=500, retries=2, id="42c4bdfe-0ccc-4e9e-8816-7f88421b50f8", sockets=6})
+newServer({address="10.8.0.13:1653", name="gw07", weight=500, retries=2, id="1c961f33-3a09-4b40-ae9d-5b5a8dd71061", sockets=6})
 {%- elif 'vie01' in salt['pillar.get']('netbox:site:slug') %}
-newServer({address="10.8.0.29:1653", name="web03", weight=3, retries=2, id="23b0121d-91c5-4338-8c5a-cc8ba6f2ca8d", sockets=6})
-newServer({address="10.8.0.30:1653", name="web04", weight=3, retries=2, id="0ed35651-7766-492c-ab44-562e76d395b6", sockets=6})
-newServer({address="10.8.0.32:1653", name="gw04", weight=3, retries=2, id="fec91b13-6d71-4162-92a5-68c197ee99c4", sockets=6})
-newServer({address="10.8.0.33:1653", name="gw05", weight=3, retries=2, id="24d189ad-2070-458d-b34a-7c0c22ba7bcd", sockets=6})
+newServer({address="10.8.0.29:1653", name="web03", weight=500, retries=2, id="23b0121d-91c5-4338-8c5a-cc8ba6f2ca8d", sockets=6})
+newServer({address="10.8.0.30:1653", name="web04", weight=500, retries=2, id="0ed35651-7766-492c-ab44-562e76d395b6", sockets=6})
+newServer({address="10.8.0.32:1653", name="gw04", weight=500, retries=2, id="fec91b13-6d71-4162-92a5-68c197ee99c4", sockets=6})
+newServer({address="10.8.0.33:1653", name="gw05", weight=500, retries=2, id="24d189ad-2070-458d-b34a-7c0c22ba7bcd", sockets=6})
 {%- else %}
 newServer({address="1.1.1.1", name="anycastCF"})
 {%- endif %}
 
 setWHashedPertubation(3962345)
-setServerPolicy(wrandom)
+setServerPolicy(chashed)
 
 -- ask authorative servers for ffmuc.net directly
 {%- if 'authorative-dns' in salt['pillar.get']('netbox:tag_list', []) %}


### PR DESCRIPTION
Set the backend server selection to chashed, which concentrates queries for the same domains from any dnsdist to the same recursors, improving the cache usage on the recursors.

The documentation recommends to set the weights between 100-1000, with 100 the distribution was a bit imbalanced, with 500 it is good (see first screenshot).

<details>
<summary>Here are a few monitoring screenshots showing the effects:</summary>
(The first day shown having the old wrandom active, then two days with chashed, and then back to wrandom)

While on average the incoming requests to the recursors stayed roughly the same:

![image](https://github.com/freifunkMUC/ffmuc-salt-public/assets/28812678/63b6eef5-860c-4016-88a8-b4f4599fc4c8)

The outgoing queries decreased a bit:

![image](https://github.com/freifunkMUC/ffmuc-salt-public/assets/28812678/007f0192-2e0e-4564-8353-6cadb6948f14)

The response times decreased a bit:

![image](https://github.com/freifunkMUC/ffmuc-salt-public/assets/28812678/b6cb2fb5-6454-43f3-90fa-75649bd4b2f4)

And the packet cache & recursor cache hit ratio increased:

![image](https://github.com/freifunkMUC/ffmuc-salt-public/assets/28812678/d95ee18a-1d1a-4d55-a5f5-4f9a29e1e98d)

While (recursor) cache size decreased:

![image](https://github.com/freifunkMUC/ffmuc-salt-public/assets/28812678/e17d6154-d546-4ce9-8182-f53301a71e43)

</details>

https://dnsdist.org/guides/serverselection.html