### PR TITLE
Enable usage of global http2 enabling (available since nginx 1.25.1)

### DIFF
--- a/nginx/domains/apt.ffmuc.net.conf
+++ b/nginx/domains/apt.ffmuc.net.conf
@@ -4,8 +4,8 @@ proxy_cache_path /var/cache/nginx-apt levels=1:2 keys_zone=apt_cache:10m inactiv
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     server_name apt.ffmuc.net apt.in.ffmuc.net;
 

--- a/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
+++ b/nginx/domains/bitte-router-erneuern.ffmuc.net.conf
@@ -2,8 +2,8 @@
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name bitte-router-erneuern.ffmuc.net;
 
     return 301 https://ffmuc.net/freifunkmuc/2023/12/08/supportende-von-8-64-routern/;

--- a/nginx/domains/broker.ffmuc.net.conf
+++ b/nginx/domains/broker.ffmuc.net.conf
@@ -9,8 +9,8 @@ upstream wgkex_backend {
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name broker.ffmuc.net wgkex.ffmuc.net;
 
     root /srv/www/{{ domain }};

--- a/nginx/domains/byro.ffmuc.net.conf
+++ b/nginx/domains/byro.ffmuc.net.conf
@@ -2,8 +2,8 @@ upstream byro_upstream {
     server docker06.ov.ffmuc.net:8345;
 }
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name verein.fnmuc.net verein.ffmuc.net byro.ffmuc.net;
 
     # Force HTTPS connection. This rules is domain agnostic

--- a/nginx/domains/chat.ffmuc.net.conf
+++ b/nginx/domains/chat.ffmuc.net.conf
@@ -6,8 +6,8 @@ upstream chat_backend {
 proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=mattermost_cache:10m max_size=3g inactive=120m use_temp_path=off;
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name chat.ffmuc.net chat-test.ffmuc.net;
 
     location ~ /api/v[0-9]+/(users/)?websocket$ {

--- a/nginx/domains/cloud.ffmuc.net.conf
+++ b/nginx/domains/cloud.ffmuc.net.conf
@@ -6,8 +6,8 @@ upstream cloud_backend {
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name cloud.ext.ffmuc.net cloud.ffmuc.net cloud.freifunk-muenchen.de;
 
     # Force HTTPS connection. This rules is domain agnostic

--- a/nginx/domains/conferencemapper.ffmuc.net.conf
+++ b/nginx/domains/conferencemapper.ffmuc.net.conf
@@ -8,8 +8,8 @@ upstream conferencemapper_upstream {
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     server_name {{ domain }};
 

--- a/nginx/domains/doh.ffmuc.net.conf
+++ b/nginx/domains/doh.ffmuc.net.conf
@@ -34,8 +34,8 @@ server {
     error_log  /var/log/nginx/{{ domain }}_error.log;
 }
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
 
     server_name dns.ffmuc.net doh.ffmuc.net dot.ffmuc.net anycast.ffmuc.net anycast01.ffmuc.net anycast02.ffmuc.net;
 

--- a/nginx/domains/ffmuc.net.conf
+++ b/nginx/domains/ffmuc.net.conf
@@ -10,8 +10,8 @@ upstream wiki_upstream {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name ffmuc.net 
         www.ffmuc.net 
         wiki.ffmuc.net
@@ -31,8 +31,8 @@ server {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name
         www.muenchen.freifunk.net muenchen.freifunk.net
         www.münchen.freifunk.net münchen.freifunk.net

--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -2,8 +2,8 @@
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    listen 443 ssl http2 default_server;
-    listen [::]:443 ssl http2 default_server;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
     server_name firmware.ffmuc.net firmware.in.ffmuc.net "";
 
     client_max_body_size 2048M;

--- a/nginx/domains/fnmuc.net.conf
+++ b/nginx/domains/fnmuc.net.conf
@@ -2,8 +2,8 @@
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name fnmuc.net;
 
     return 301 https://ffmuc.net/wiki/doku.php?id=ev:start;

--- a/nginx/domains/map.ffmuc.net.conf
+++ b/nginx/domains/map.ffmuc.net.conf
@@ -6,9 +6,9 @@ proxy_cache_path /var/cache/nginx-map levels=1:2 keys_zone=map_cache:10m inactiv
 
 server {
    listen 80;
-	listen [::]:80;
-	listen 443 ssl http2;
-   listen [::]:443 ssl http2;
+   listen [::]:80;
+   listen 443 ssl;
+   listen [::]:443 ssl;
    server_name map.ext.ffmuc.net map.ffmuc.net map.freifunk-muenchen.de;
    
    # Force HTTPS connection. This rules is domain agnostic

--- a/nginx/domains/meet.ffmuc.net.conf
+++ b/nginx/domains/meet.ffmuc.net.conf
@@ -23,8 +23,8 @@ server {
     return 301 https://meet.ffmuc.net$request_uri;
 }
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name meet.ffmuc.net meet-test.ffmuc.net ffmeet.de *.ffmeet.de ffmeet.net *.ffmeet.net klassenkonferenz.de;
 
     add_header Strict-Transport-Security "max-age=31536000";

--- a/nginx/domains/offline.ffmuc.net.conf
+++ b/nginx/domains/offline.ffmuc.net.conf
@@ -2,8 +2,8 @@
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name offline.ffmuc.net;
 
     return 307 https://wiki.freifunk.net/Mein_Freifunk_funktioniert_nicht_mehr;

--- a/nginx/domains/omada.ffmuc.net.conf
+++ b/nginx/domains/omada.ffmuc.net.conf
@@ -4,12 +4,12 @@ upstream omada_backend {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     listen 80;
     listen [::]:80;
-    listen 8043 ssl http2;
-    listen [::]:8043 ssl http2;
+    listen 8043 ssl;
+    listen [::]:8043 ssl;
 
     server_name omada.ext.ffmuc.net omada.ffmuc.net omada;
 

--- a/nginx/domains/recorder.ffmuc.net.conf
+++ b/nginx/domains/recorder.ffmuc.net.conf
@@ -1,6 +1,6 @@
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name recorder.ffmuc.net;
 
     root /srv/www/recorder.ffmuc.net;

--- a/nginx/domains/social.ffmuc.net.conf
+++ b/nginx/domains/social.ffmuc.net.conf
@@ -22,8 +22,8 @@ server {
 }
 
 server {
-  listen 443 ssl http2;
-  listen [::]:443 ssl http2;
+  listen 443 ssl;
+  listen [::]:443 ssl;
   server_name social.ffmuc.net;
 
   ssl_protocols TLSv1.2 TLSv1.3;

--- a/nginx/domains/stats.ffmuc.net.conf
+++ b/nginx/domains/stats.ffmuc.net.conf
@@ -9,8 +9,8 @@ proxy_cache_path /var/cache/nginx/grafana_datasources keys_zone=grafana_datasour
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name stats.ffmuc.net graphs.ext.ffmuc.net;
     
     # Force HTTPS connection. This rules is domain agnostic

--- a/nginx/domains/streaming.ffmuc.net.conf
+++ b/nginx/domains/streaming.ffmuc.net.conf
@@ -8,8 +8,8 @@ proxy_cache_path /var/cache/nginx-streaming levels=1:2 keys_zone=streaming_cache
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name stream.ffmuc.net;
     return 301 https://streaming.ffmuc.net$request_uri;
 }
@@ -17,8 +17,8 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name streaming.ffmuc.net;
 
     root /srv/www/{{ domain }};

--- a/nginx/domains/tickets.ffmuc.net.conf
+++ b/nginx/domains/tickets.ffmuc.net.conf
@@ -2,8 +2,8 @@ upstream tickets_upstream {
         server docker05.ov.ffmuc.net:8002;
 }
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name tickets.ffmuc.net;
     
     # Force HTTPS connection. This rules is domain agnostic

--- a/nginx/domains/tiles.ffmuc.net.conf
+++ b/nginx/domains/tiles.ffmuc.net.conf
@@ -18,8 +18,8 @@ proxy_cache_lock on;
 proxy_cache_lock_age 10s;
 
 server {
-	listen 443 ssl http2;
-	listen [::]:443 ssl http2;
+	listen 443 ssl;
+	listen [::]:443 ssl;
 	server_name tiles.ext.ffmuc.net a.tiles.ext.ffmuc.net b.tiles.ext.ffmuc.net c.tiles.ext.ffmuc.net tiles.ffmuc.net;
 
 	location /osm/ {

--- a/nginx/domains/tv.ffmuc.net.conf
+++ b/nginx/domains/tv.ffmuc.net.conf
@@ -8,8 +8,8 @@ proxy_cache_path /var/cache/nginx-tv levels=1:2 keys_zone=tv_cache:10m max_size=
 server {
     listen 80;
     listen [::]:80;
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name tv.ffmuc.net;
 
     root /srv/www/{{ domain }};

--- a/nginx/domains/uisp.ffmuc.net.conf
+++ b/nginx/domains/uisp.ffmuc.net.conf
@@ -8,8 +8,8 @@ upstream uisp_inform_backend {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     listen 80;
     listen [::]:80;
     listen 8080;

--- a/nginx/domains/unifi.ffmuc.net.conf
+++ b/nginx/domains/unifi.ffmuc.net.conf
@@ -8,8 +8,8 @@ upstream unifi_inform_backend {
 }
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     listen 80;
     listen [::]:80;
     listen 8080;

--- a/nginx/files/default.conf
+++ b/nginx/files/default.conf
@@ -1,8 +1,8 @@
 server {
     listen 80 default;
     listen [::]:80 default;
-    listen 443 ssl http2 default;
-    listen [::]:443 ssl http2 default;
+    listen 443 ssl default;
+    listen [::]:443 ssl default;
 
     server_name _;
 

--- a/nginx/files/nginx.conf.jinja
+++ b/nginx/files/nginx.conf.jinja
@@ -29,13 +29,13 @@ http {
 	sendfile_max_chunk 512k;
 	server_tokens off;
 
-	server_names_hash_bucket_size 64;
+	http2 on;
+
+	server_names_hash_bucket_size 128;
 	# server_name_in_redirect off;
 
 	include /etc/nginx/mime.types;
 	types {
-		# nginx's default mime.types doesn't include a mapping for wasm
-		application/wasm	wasm;
 		text/plain                 manifest;
 		application/manifest+json  webmanifest;
 		application/geo+json       geojson;
@@ -87,7 +87,7 @@ http {
 		application/ecmascript application/json image/svg+xml;
 
 	# Set hint which webfrontend is used
-	add_header X-FFMuc-Edge "{{ grains.id.split('.')[0] }}";
+	add_header X-FFMuc-Edge "{{ grains.id.split('.')[0] }}" always;
 	map $http_upgrade $connection_upgrade {
 		default upgrade;
 		''      close;

--- a/nginx/files/nginx_vhost.jinja2
+++ b/nginx/files/nginx_vhost.jinja2
@@ -3,8 +3,8 @@
 ###
 
 server {
-    listen 443 ssl http2;
-    listen [::]:443 ssl http2;
+    listen 443 ssl;
+    listen [::]:443 ssl;
     server_name {{ domain }};
 
     root /srv/www/{{ domain }};


### PR DESCRIPTION
This is set to draft as we are running nginx stable (current latest 1.24.0) which does not have this flag yet.

https://nginx.org/en/docs/http/ngx_http_v2_module.html#http2