### PR TITLE
check headers for firmware version

### DIFF
--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -1,3 +1,48 @@
+map $http_user_agent $autoupdater {
+    "Gluon Autoupdater (using libuclient)" 1;
+    default                                0;
+}
+
+map $http_x_firmware_version $firmwareVersion {
+    "~^v(\d+)\.(\d+)\.(\d+)(-next)?" $1.$2.$3$4;
+    # old next versions v2020.3.4.1-next1 until v2020.3.5.0-next1
+    "~^v2020\.3\..*-next"    "next-v2021";
+    default                  "unknown";
+}
+
+map $firmwareVersion $targetDirectory {
+    # OpenWrt 19.07 (Both Gluon v2019.1.x and v2020.1.x)
+    # Old autoupdaters do not send the X-Firmware-Version header
+    "unknown"                           $gluon_v2019_1_x;
+    "~^2020\.3\.[2-5]"                  $gluon_v2019_1_x;
+
+    # OpenWrt 21.02
+    "~^2021\.\d+\."                     $gluon_v2021_1_x;
+    "~^2022\.[1-5]\."                   $gluon_v2021_1_x;
+    "~^2022\.5\.[0-7]"                  $gluon_v2021_1_x;
+    "next-v2021"                        $gluon_v2021_1_x;
+    "~^2021\.(8|10|11)\.\d+-next"       $gluon_v2021_1_x;
+    "~^2022.2.1-next"                   $gluon_v2021_1_x;
+
+    # OpenWrt 22.03
+    "~^2022\.10\."                      $gluon_v2022_1_x;
+    "~^2023\.[1-5]\."                   $gluon_v2022_1_x;
+    "~^2022\.(5|9|10)\.\d+-next$"       $gluon_v2022_1_x;
+
+    # OpenWRT 22.03 (still)
+    "~^2023\.(8|11)\."                  $gluon_v2023_1_x;
+    "~^2024\.([0-9]|10|11])\.\d+$"      $gluon_v2023_1_x;
+
+    # OpenWrt 23.05
+    "~^2023\.12\.2-next$"               $gluon_v2023_2_x;
+    "~^2024\.([0-9]|10|11)\.\d+-next$"  $gluon_v2023_2_x;
+
+    # OpenWrt 24.10
+    # TBD
+
+    # Else keep requested branch folder
+    default              "keep";
+}
 
 server {
     listen 80 default_server;
@@ -20,6 +65,31 @@ server {
             return 301 https://firmware.ffmuc.net;
         }
     }
+
+    # temporary location to test the new firmware redirect feature
+    location ~ ^/(stable|testing|experimental)-debug/ {
+        # for accessing it e.g. via ffmuc.net/firmware
+        add_header Access-Control-Allow-Origin "*";
+
+        if ($autoupdater = "0") {
+            break;
+        }
+
+        # Add Gluon releases here that allow an upgrade path to the latest version
+        # https://github.com/freifunk-gluon/gluon/wiki/Release-life-cycle#migration-paths-diagram
+        set $gluon_v2019_1_x gluon_v2021.1.x; # we do not have an upgrade path for v2018 and earlier yet
+        set $gluon_v2021_1_x gluon_v2021.1.x;
+        set $gluon_v2022_1_x gluon_v2023.1.x;
+        set $gluon_v2023_1_x gluon_v2023.1.x;
+        set $gluon_v2023_2_x gluon_v2023.2.x;
+
+        if ($targetDirectory = "keep") {
+            break;
+        }
+
+        rewrite ^/(stable|testing|experimental)-debug/(.*) /$targetDirectory/$2 redirect;
+    }
+
 
     location ~ ^/(stable|testing|experimental)/ {
         # for accessing it e.g. via ffmuc.net/firmware


### PR DESCRIPTION
early draft for ngnix totaly untested (just ideas how to use the user agent and the firmware header)

https://gluon.readthedocs.io/en/v2023.2.x/releases/v2023.2.html#important-notes
Upgrades to gluon v2023.2 and later releases are only supported from releases gluon v2022.1 and later

FFMUC (from map):
- v2024.4.2-next (gluon-v2023.2.2)
- v2024.3.2-next (gluon-v2023.2.2)

https://gluon.readthedocs.io/en/v2023.1.x/releases/v2023.1.html#important-notes
Upgrades to gluon v2023.1 and later releases are only supported from releases gluon v2021.1 and later.

FFMUC (from map):
- v2024.1.1 - v2024.4.2 (gluon-v2023.1.2)


the firmware Version header is set to: /lib/gluon/release

grische:
> Falls Firmware ohne X-Firmware kommt, dann redirect auf legacy-v2022.5.x
> Falls Firmware X-Firmware <v2022.5.8 kommt, dann redirecte auf legacy-v2022.5.x
> Falls Firmware X-Firmware =>v2022.5.8 und <2024.8.1 kommt, dann redirecte auf legacy-v2024.7.x
> Falls Firmware >=v2024.8.1 kommt, dann redirecte auf stable