### PR TITLE
include redirect for muenchen.freifunk.net/ulm

### DIFF
--- a/nginx/domains/ffmuc.net.include
+++ b/nginx/domains/ffmuc.net.include
@@ -15,7 +15,7 @@ location /favicon.ico {
 }
 
 # Point SSID-URL to ffmuc.net
-rewrite ^/(uml_.*|muc_.*|gauting|freising|augsburg|welt)$ https://ffmuc.net redirect;
+rewrite ^/(uml_.*|muc_.*|gauting|freising|augsburg|welt|ulm)$ https://ffmuc.net redirect;
 
 location ~ ^/speed(.*)$ {
 	return 301 https://speed.ffmuc.net$1;


### PR DESCRIPTION
include redirect for https://muenchen.freifunk.net/ulm atm you get a 404