### PR TITLE
Update yanic to v1.5.2

### DIFF
--- a/yanic/init.sls
+++ b/yanic/init.sls
@@ -15,7 +15,7 @@
 yanic:
   pkg.installed:
     - sources:
-      - yanic: https://apt.ffmuc.net/yanic_1.2.1-1_amd64.deb
+      - yanic: https://apt.ffmuc.net/yanic_1.5.2-2_amd64.deb
   service.running:
     - enable: True
     - require:


### PR DESCRIPTION
The deployment ran into bug https://github.com/saltstack/salt/issues/66459 but a manual `dpkg -i` did the trick for now.