### PR TITLE
snmpd: ignore Docker network interfaces

### DIFF
--- a/snmpd/snmpd.conf
+++ b/snmpd/snmpd.conf
@@ -69,27 +69,14 @@ sysServices    72
 # Network interfaces
 #
 
-{%- for interface in salt['grains.get']('ip_interfaces') | sort %}
+{%- set ip_interfaces = salt['grains.get']('ip_interfaces') | sort %}
+{%- set hwaddr_interfaces = salt['grains.get']('hwaddr_interfaces') %}
+{%- for interface in ip_interfaces if interface is not match('^veth') and ( interface is not match('^br-') or interface not in hwaddr_interfaces or hwaddr_interfaces[interface] | string is not match('^02:42') ) %}
 {%- if 'vlan' in interface or 'br0' in interface or 'eth0' in interface or 'enp' in interface %}
 interface {{ interface }} 6 1000000000
 {%- else %}
 interface {{ interface }} 6 100000000
 {%- endif %}
-{%- endfor %}
-{%- set ovpn_networks = [] %}
-{%- for netname, network in salt['pillar.get']('ovpn', {}).items () if grains['id'] in network %}
-  {%- do ovpn_networks.append (netname) %}
-{%- endfor %}
-{%- for netname in ovpn_networks|sort %}
-  {%- set network = salt['pillar.get']('ovpn:' ~ netname) %}
-  {%- set network_config = network.get ('config') %}
-  {%- set host_stanza = network.get (grains['id']) %}
-  {%- set host_config = host_stanza.get ('config', {}) %}
-  {%- set interface = host_config.get ('interface', network_config.get ('interface')) %}
-  {%- if loop.first %}
-# OpenVPN interfaces
-  {%- endif %}
-interface	{{ interface }}	6	100000000
 {%- endfor %}
 
 #


### PR DESCRIPTION
## Problem

When setting up ft04 I noticed that Influx doesn't show stats for the ft04_v* interfaces on the vm-host.
In the log I then found:

```
Aug 16 11:11:02 metrics influxd-systemd-start.sh[579]: ts=2024-08-16T09:11:02.736381Z lvl=warn msg="max-values-per-tag limit may be exceeded soon" log_id=0qAP5cnl000 service=store perc=100% n=100000 max=100000 db_instance=librenms measurement=ports tag=ifName
Aug 16 11:11:02 metrics influxd-systemd-start.sh[579]: ts=2024-08-16T09:11:02.738841Z lvl=warn msg="max-values-per-tag limit may be exceeded soon" log_id=0qAP5cnl000 service=store perc=80% n=80783 max=100000 db_instance=ffmuc_other measurement=net tag=interface
```

This is due to Docker containers creating new veth interfaces with different names whenever containers are recreated, and new br interfaces when networks are recreated. Especially the amount of different veth interfaces (i.e. the cardinality of the Influx measurement) over time is huge, it makes up around 95% of the interfaces Influx (and LibreNMS).
As a first countermeasure I removed all series from the `ports` measurement where the `ifName` starts with `veth` before 2024-06-30, and lowered the cardinality from just below the 1005 to ~8k (`SHOW TAG VALUES CARDINALITY WITH KEY = "ifName"`).
A few minutes afterwards the two ft04_v* interfaces started to show up in Influx.

## Solution
Let's exclude the Docker `br-` and `veth` interfaces from SNMP measurements, thus not sending their data to LibreNMS, thus not sending the data to Influx.
I chose this over increasing the max-values-per-tag-limit, because I think we don't have much use for historical Docker interface stats (especially as you can't really match them to the respective container anymore), and InfluxDB (and LibreNMS) should also be very happy about a much reduced load/database size.

The filter for the `br-` interfaces checks whether their MAC address starts with `02:42`, which appears to be the prefix that Docker uses, as not to match our bridges on the gateways.

&nbsp;

The second line regarding `db_instance=ffmuc_other measurement=net` comes from Telegraf collecting network stats on the VMs directly. The filtering there (if possible) is still TODO, in a separate PR.