### PR TITLE
Update batman-adv to status quo, add clone state

### DIFF
--- a/systemd-networkd/init.sls
+++ b/systemd-networkd/init.sls
@@ -1,11 +1,20 @@
 {%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
 
 {%- if 'nextgen-gateway' in role %}
-/usr/src/batman-adv-2021.5/dkms.conf:
+{%- set batman_version = '2024.1' %}
+/usr/src/batman-adv-{{ batman_version }}:
+  git.latest:
+    - name: https://github.com/open-mesh-mirror/batman-adv.git
+    - rev: v{{ batman_version }}
+    - target: /usr/src/batman-adv-{{ batman_version }}
+    - force_reset: True
+    - require_in: /usr/src/batman-adv-{{ batman_version }}/dkms.conf
+
+/usr/src/batman-adv-{{ batman_version }}/dkms.conf:
   file.managed:
     - contents: |
         PACKAGE_NAME=batman-adv
-        PACKAGE_VERSION=2021.5
+        PACKAGE_VERSION={{ batman_version }}
 
         DEST_MODULE_LOCATION=/extra
         BUILT_MODULE_NAME=batman-adv
@@ -197,4 +206,3 @@ systemd-networkd-reload:
       - cmd: systemd-networkd-reload
 {% endif %}
 {% endfor %}
-


### PR DESCRIPTION
Reflects the status quo on the gateways (we are running batman-adv v2024.1), and also adds an automatic repo clone step for the respective version.
The dkms build & install itself need some more manual steps, see https://ffmuc.net/wiki/doku.php?id=admin:start#batdman-adv_updates_dkms (to be proofread, non-public page)