### PR TITLE
Improve Telegraf JSON parsing template for dhcpd leases

### DIFF
--- a/telegraf/files/in_dhcpd-pool.conf
+++ b/telegraf/files/in_dhcpd-pool.conf
@@ -3,5 +3,31 @@
      "/usr/bin/dhcpd-pools -c /etc/dhcp/dhcpd.conf --format=j",
    ]
    timeout = "5s"
-   name_suffix = "_exec"
+   name_override = "dhcpd_pools_shared_networks"
    data_format = "json"
+   json_query = "shared-networks"
+   tag_keys = [
+     "location",
+   ]
+
+[[inputs.exec]]
+   commands = [
+     "/usr/bin/dhcpd-pools -c /etc/dhcp/dhcpd.conf --format=j",
+   ]
+   timeout = "5s"
+   name_override = "dhcpd_pools_subnets"
+   data_format = "json"
+   json_query = "subnets"
+   tag_keys = [
+     "location",
+     "range",
+   ]
+
+[[inputs.exec]]
+   commands = [
+     "/usr/bin/dhcpd-pools -c /etc/dhcp/dhcpd.conf --format=j",
+   ]
+   timeout = "5s"
+   name_override = "dhcpd_pools_summary"
+   data_format = "json"
+   json_query = "summary"


### PR DESCRIPTION
**Before:**
With the current format it's impossible to create any useful Grafana graphs except for the total summary across all DHCP networks, even though the statistics per domain would be more interesting in many cases.
Each DHCP network is just referenced by an array index number, which makes it hard to find the data for a specific domain.
The measurement name is a nondescript `exec_exec`.

`> exec_exec,host=gw04.in.ffmuc.net shared-networks_0_defined=2037,shared-networks_0_free=1994,shared-networks_0_touched=1923,shared-networks_0_used=43,shared-networks_10_defined=2037,shared-networks_10_free=2023,shared-networks_10_touched=1921,shared-networks_10_used=14,shared-networks_11_defined=2037,shared-networks_11_free=1981,shared-networks_11_touched=1885,shared-networks_11_used=56,shared-networks_12_defined=2037,shared-networks_12_free=2006,shared-networks_12_touched=1927,shared-networks_12_used=31,shared-networks_13_defined=2037,shared-networks_13_free=1984,shared-networks_13_touched=1947,shared-networks_13_used=53,shared-networks_14_defined=2037,shared-networks_14_free=2012,shared-networks_14_touched=1874,shared-networks_14_used=25,shared-networks_15_defined=2037,shared-networks_15_free=1927,shared-networks_15_touched=1603,shared-networks_15_used=110,shared-networks_16_defined=2037,shared-networks_16_free=1928,shared-networks_16_touched=1725,shared-networks_16_used=109,shared-networks_17_defined=2037,shared-networks_17_free=1998,shared-networks_17_touched=1821,shared-networks_17_used=39,shared-networks_18_defined=2037,shared-networks_18_free=1955,shared-networks_18_touched=1694,shared-networks_18_used=82,shared-networks_1_defined=2037,shared-networks_1_free=2033,shared-networks_1_touched=1349,shared-networks_1_used=4,shared-networks_2_defined=2037,shared-networks_2_free=2037,shared-networks_2_touched=2037,shared-networks_2_used=0,shared-networks_3_defined=2037,shared-networks_3_free=2018,shared-networks_3_touched=1998,shared-networks_3_used=19,shared-networks_4_defined=2037,shared-networks_4_free=2024,shared-networks_4_touched=1673,shared-networks_4_used=13,shared-networks_5_defined=2037,shared-networks_5_free=1999,shared-networks_5_touched=1953,shared-networks_5_used=38,shared-networks_6_defined=2037,shared-networks_6_free=1970,shared-networks_6_touched=1901,shared-networks_6_used=67,shared-networks_7_defined=2037,shared-networks_7_free=2012,shared-networks_7_touched=1925,shared-networks_7_used=25,shared-networks_8_defined=2037,shared-networks_8_free=2021,shared-networks_8_touched=1944,shared-networks_8_used=16,shared-networks_9_defined=2037,shared-networks_9_free=2000,shared-networks_9_touched=1948,shared-networks_9_used=37,subnets_0_defined=2037,subnets_0_free=1970,subnets_0_touched=1901,subnets_0_used=67,subnets_10_defined=2037,subnets_10_free=2024,subnets_10_touched=1673,subnets_10_used=13,subnets_11_defined=2037,subnets_11_free=2018,subnets_11_touched=1998,subnets_11_used=19,subnets_12_defined=2037,subnets_12_free=1994,subnets_12_touched=1923,subnets_12_used=43,subnets_13_defined=2037,subnets_13_free=2033,subnets_13_touched=1349,subnets_13_used=4,subnets_14_defined=2037,subnets_14_free=2037,subnets_14_touched=2037,subnets_14_used=0,subnets_15_defined=2037,subnets_15_free=1984,subnets_15_touched=1947,subnets_15_used=53,subnets_16_defined=2037,subnets_16_free=1999,subnets_16_touched=1953,subnets_16_used=38,subnets_17_defined=2037,subnets_17_free=1981,subnets_17_touched=1885,subnets_17_used=56,subnets_18_defined=2037,subnets_18_free=2006,subnets_18_touched=1927,subnets_18_used=31,subnets_1_defined=2037,subnets_1_free=2012,subnets_1_touched=1925,subnets_1_used=25,subnets_2_defined=2037,subnets_2_free=2021,subnets_2_touched=1944,subnets_2_used=16,subnets_3_defined=2037,subnets_3_free=2000,subnets_3_touched=1948,subnets_3_used=37,subnets_4_defined=2037,subnets_4_free=2023,subnets_4_touched=1921,subnets_4_used=14,subnets_5_defined=2037,subnets_5_free=2012,subnets_5_touched=1874,subnets_5_used=25,subnets_6_defined=2037,subnets_6_free=1927,subnets_6_touched=1603,subnets_6_used=110,subnets_7_defined=2037,subnets_7_free=1928,subnets_7_touched=1725,subnets_7_used=109,subnets_8_defined=2037,subnets_8_free=1998,subnets_8_touched=1821,subnets_8_used=39,subnets_9_defined=2037,subnets_9_free=1955,subnets_9_touched=1694,subnets_9_used=82,summary_defined=38703,summary_free=37922,summary_touched=35048,summary_used=781 1726689252000000000`

![Bildschirmfoto_20240918_215553](https://github.com/user-attachments/assets/c6111466-4849-421c-873a-f88d3d82bc3e)


**After:**
Now we have three separate measurements. The first two each with one series per domain, using the `location` tag (and `subnet` for `dhcpd_pools_subnets`, as we could potentially add multiple DHCP ranges per network/location).
The third measurement is the total summary.
We have to run the `dhcpd-pools` command three times now, neither the `json` nor the `json_v2` parser plugins were able to create multiple measurements from one input run.
```
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=augsburg defined=2037,free=1994,touched=1923,used=43 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=city defined=2037,free=2033,touched=1349,used=4 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=events defined=2037,free=2037,touched=2037,used=0 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=freising defined=2037,free=2018,touched=1998,used=19 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=gauting defined=2037,free=2023,touched=1672,used=14 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=mitte defined=2037,free=1999,touched=1953,used=38 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=muc_cty defined=2037,free=1971,touched=1902,used=66 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=muc_nord defined=2037,free=2013,touched=1926,used=24 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=muc_ost defined=2037,free=2021,touched=1944,used=16 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=muc_sued defined=2037,free=1999,touched=1947,used=38 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=muc_west defined=2037,free=2022,touched=1920,used=15 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=nordwest defined=2037,free=1982,touched=1886,used=55 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=sued defined=2037,free=2007,touched=1928,used=30 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=ulm defined=2037,free=1983,touched=1946,used=54 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=uml_nord defined=2037,free=2012,touched=1874,used=25 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=uml_ost defined=2037,free=1927,touched=1603,used=110 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=uml_sued defined=2037,free=1929,touched=1726,used=108 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=uml_west defined=2037,free=1999,touched=1822,used=38 1726689195000000000
> dhcpd_pools_shared_networks,host=gw04.in.ffmuc.net,location=welt defined=2037,free=1955,touched=1694,used=82 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=muc_cty,range=10.80.128.10\ -\ 10.80.135.254 defined=2037,free=1971,touched=1902,used=66 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=muc_nord,range=10.80.136.10\ -\ 10.80.143.254 defined=2037,free=2013,touched=1926,used=24 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=muc_ost,range=10.80.144.10\ -\ 10.80.151.254 defined=2037,free=2021,touched=1944,used=16 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=muc_sued,range=10.80.152.10\ -\ 10.80.159.254 defined=2037,free=1999,touched=1947,used=38 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=muc_west,range=10.80.160.10\ -\ 10.80.167.254 defined=2037,free=2022,touched=1920,used=15 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=uml_nord,range=10.80.168.10\ -\ 10.80.175.254 defined=2037,free=2012,touched=1874,used=25 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=uml_ost,range=10.80.176.10\ -\ 10.80.183.254 defined=2037,free=1927,touched=1603,used=110 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=uml_sued,range=10.80.184.10\ -\ 10.80.191.254 defined=2037,free=1929,touched=1726,used=108 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=uml_west,range=10.80.192.10\ -\ 10.80.199.254 defined=2037,free=1999,touched=1822,used=38 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=welt,range=10.80.200.10\ -\ 10.80.207.254 defined=2037,free=1955,touched=1694,used=82 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=gauting,range=10.80.208.10\ -\ 10.80.215.254 defined=2037,free=2023,touched=1672,used=14 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=freising,range=10.80.216.10\ -\ 10.80.223.254 defined=2037,free=2018,touched=1998,used=19 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=augsburg,range=10.80.224.10\ -\ 10.80.231.254 defined=2037,free=1994,touched=1923,used=43 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=city,range=10.86.0.10\ -\ 10.86.7.254 defined=2037,free=2033,touched=1349,used=4 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=events,range=10.86.8.10\ -\ 10.86.15.254 defined=2037,free=2037,touched=2037,used=0 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=ulm,range=10.86.16.10\ -\ 10.86.23.254 defined=2037,free=1983,touched=1946,used=54 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=mitte,range=10.86.128.10\ -\ 10.86.135.254 defined=2037,free=1999,touched=1953,used=38 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=nordwest,range=10.86.136.10\ -\ 10.86.143.254 defined=2037,free=1982,touched=1886,used=55 1726689195000000000
> dhcpd_pools_subnets,host=gw04.in.ffmuc.net,location=sued,range=10.86.144.10\ -\ 10.86.151.254 defined=2037,free=2007,touched=1928,used=30 1726689195000000000
> dhcpd_pools_summary,host=gw04.in.ffmuc.net defined=38703,free=37924,touched=35050,used=779 1726689195000000000
```

This way we can properly monitor each segment separately and show them in the dashboards.