### PR TITLE
dhcp-server: implement captive portal option (RFC8910)

### DIFF
--- a/dhcp-server/dhcpd.conf
+++ b/dhcp-server/dhcpd.conf
@@ -8,6 +8,7 @@ option space ubnt;
 option space omada;
 option ubnt.unifi-address code 1 = ip-address;
 option omada-controller-address code 138 = ip-address;
+option captive-portal-url code 114 = text;
 
 class "ubnt" {
         match if substring (option vendor-class-identifier, 0, 4) = "ubnt";
@@ -44,6 +45,7 @@ shared-network "{{ name }}" {
                         option omada-controller-address 5.1.66.255;
                 }
 		option interface-mtu            1280;
+		option captive-portal-url "urn:ietf:params:capport:unrestricted";
 		{%- endif  %}
 		{%- endfor  %}
 	}


### PR DESCRIPTION
Clients observing the URI value "urn:ietf:params:capport:unrestricted" may forego time-consuming forms of captive portal detection.

https://datatracker.ietf.org/doc/html/rfc8910

---

Another option is to provide an URL to an Captive Portal API ([RFC8908](https://datatracker.ietf.org/doc/html/rfc8908)). This can be static JSON. In the Freifunk context the `venue-info-url` is probably the most interesting part. When set Users of Android 11 an up are getting a Notifcation which links to the URL provided via `venue-info-url`. Also it's visible in the Details of the Wifi. For iOS the Link will also be visible there.

https://developer.android.com/about/versions/11/features/captive-portal?hl=de

Providing an actual Captive Portal API hoewer comes with the drawback of requiring a request to the Captive Portal API until a client knows it isn't restricted. Not worse then the current check most clients will presumably do currently but also not better.

For an example of an Captive Portal API see https://darmstadt.freifunk.net/captive