### PR TITLE
firmware: make new firmware redirect public

### DIFF
--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -68,7 +68,7 @@ server {
     }
 
     # temporary location to test the new firmware redirect feature
-    location ~ ^/(stable|testing|experimental)-debug/ {
+    location ~ ^/(stable|testing|experimental)/ {
         # for accessing it e.g. via ffmuc.net/firmware
         add_header Access-Control-Allow-Origin "*";
 
@@ -89,13 +89,7 @@ server {
             break;
         }
 
-        rewrite ^/(stable|testing|experimental)-debug/(.*) /$targetDirectory/$1/$2 redirect;
-    }
-
-
-    location ~ ^/(stable|testing|experimental)/ {
-        # for accessing it e.g. via ffmuc.net/firmware
-        add_header Access-Control-Allow-Origin "*";
+        rewrite ^/(stable|testing|experimental)/(.*) /$targetDirectory/$1/$2 redirect;
     }
 
     location ^~ /.well-known/acme-challenge/ {


### PR DESCRIPTION
I tested this briefly using curl and it LGTM:

This is our current folder structure:
```sh
$ ls -gG gluon-v*/
gluon-v2021.1.x/:
total 0
lrwxrwxrwx 1 12 Dec 15 17:13 experimental -> ../v2022.5.8
lrwxrwxrwx 1 12 Dec 15 17:12 stable -> ../v2022.5.8
lrwxrwxrwx 1 12 Dec 15 17:13 testing -> ../v2022.5.8

gluon-v2023.1.x_v2021.1.x/:
total 0
lrwxrwxrwx 1 23 Dec 15 17:15 experimental -> ../v2024.11.1_v2022.5.8
lrwxrwxrwx 1 22 Dec 15 17:14 stable -> ../v2024.9.1_v2022.5.8
lrwxrwxrwx 1 22 Dec 15 17:14 testing -> ../v2024.9.1_v2022.5.8

gluon-v2023.2.x_v2023.1.x/:
total 0
```

@T0biii any objections from your side?