### PR TITLE
run black on netbox_vms.py

### DIFF
--- a/_modules/netbox_vms.py
+++ b/_modules/netbox_vms.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
-"""WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag..
-"""
+"""WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag.."""
 
 import requests
 import logging


### PR DESCRIPTION
fixes black ci error

```cmd
Installing .[colorama]...
--- /home/runner/work/ffmuc-salt-public/ffmuc-salt-public/_modules/netbox_vms.py	2025-02-13 17:29:08.790966+00:00
+++ /home/runner/work/ffmuc-salt-public/ffmuc-salt-public/_modules/netbox_vms.py	2025-02-13 17:29:16.736272+00:00
@@ -1,8 +1,7 @@
 #!/usr/bin/python
-"""WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag..
-"""
+"""WIP module to get virtual machine data from netbox, e.g. to get all VMs with a certain tag.."""
 
 import requests
 import logging
 
 log = logging.getLogger(__name__)
would reformat /home/runner/work/ffmuc-salt-public/ffmuc-salt-public/_modules/netbox_vms.py

Oh no! 💥 💔 💥
1 file would be reformatted, 16 files would be left unchanged.
```