### PR TITLE
Rename device_role to role for Netbox v4.0

### DIFF
--- a/_pillar/netbox_new.py
+++ b/_pillar/netbox_new.py
@@ -23,7 +23,7 @@ def ext_pillar_test(minion_id, pillar, *args, **kwargs):
             device_list(name: "guardian-muc01.in.ffmuc.net", status: "ACTIVE") {
                 id
                 name
-                device_role {
+                role {
                     id
                     slug
                 }
@@ -58,7 +58,7 @@ def ext_pillar_test(minion_id, pillar, *args, **kwargs):
                     }
                 }
                 tags {
-                    
+
                 }
             }
             virtual_machine_list(name: "webfrontend03.in.ffmuc.net", status: "ACTIVE") {

--- a/certs/init.sls
+++ b/certs/init.sls
@@ -62,7 +62,7 @@ generate-dhparam:
 {% endif %}{# Certificate wont expire #}
 {% endif %}{# can ping ca #}
 
-{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
+{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:role:name')) %}
 {% set cloudflare_token = salt['pillar.get']('netbox:config_context:cloudflare:api_token') %}
 {% if ("webserver-external" in role or "jitsi meet" in role) and cloudflare_token %}
 

--- a/docker/init.sls
+++ b/docker/init.sls
@@ -1,7 +1,7 @@
 #
 # Setup docker.io
 #
-{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
+{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:role:name')) %}
 
 {% if 'docker' in role or 'mailserver' in role or 'roadwarrior' in role %}
 docker-repo-key:

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -4,7 +4,7 @@
 {% if salt['pillar.get']('netbox:role:name') %}
 {%- set role = salt['pillar.get']('netbox:role:name') %}
 {% else %}
-{%- set role = salt['pillar.get']('netbox:device_role:name') %}
+{%- set role = salt['pillar.get']('netbox:role:name') %}
 {% endif %}
 
 {% if 'buildserver' in role %}

--- a/kvm/init.sls
+++ b/kvm/init.sls
@@ -1,11 +1,7 @@
 #
 # KVM host
 #
-{% if salt['pillar.get']('netbox:role:name') %}
 {%- set role = salt['pillar.get']('netbox:role:name') %}
-{% else %}
-{%- set role = salt['pillar.get']('netbox:device_role:name') %}
-{% endif %}
 
 
 {% if 'vmhost' in role %}

--- a/nebula/files/config.yml.jinja
+++ b/nebula/files/config.yml.jinja
@@ -1,5 +1,5 @@
 {%- from "nebula/map.jinja" import nebula with context %}
-{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
+{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:role:name')) %}
 {%- set tags = salt['pillar.get']('netbox:tag_list', []) %}
 
 pki:

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -1,7 +1,7 @@
 ###
 # nginx
 ###
-{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
+{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:role:name')) %}
 {% set tags = salt['pillar.get']('netbox:tag_list', []) %}
 {% if not "jitsi meet" in role and ("webserver" in role or "webserver" in tags) %}
 

--- a/systemd-networkd/init.sls
+++ b/systemd-networkd/init.sls
@@ -1,4 +1,4 @@
-{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:device_role:name')) %}
+{%- set role = salt['pillar.get']('netbox:role:name', salt['pillar.get']('netbox:role:name')) %}
 
 {%- if 'nextgen-gateway' in role %}
 {%- set batman_version = '2024.1' %}


### PR DESCRIPTION
See https://netboxlabs.com/docs/netbox/en/stable/release-notes/version-4.0/#breaking-changes

`role` has been introduced as synonym in v3.6 (which we are currently running) and `device_role` has been removed with v4.0.