### PR TITLE
Fix speedtest

### DIFF
--- a/nginx/domains/speed.ffmuc.net.conf
+++ b/nginx/domains/speed.ffmuc.net.conf
@@ -13,16 +13,16 @@ server {
    listen 443 ssl;
    listen [::]:443 ssl;
    server_name speed.ffmuc.net speed-muc.ffmuc.net speed-vie.ffmuc.net speed4.ffmuc.net speed6.ffmuc.net speedtest.ffmuc.net;
-   gzip off; 
-        tcp_nodelay on;
-        tcp_nopush on;
-        sendfile on;
-        open_file_cache max=200000 inactive=20s;
-        open_file_cache_valid 30s;
-        open_file_cache_min_uses 2;
-        open_file_cache_errors off;
+   gzip off;
+   tcp_nodelay on;
+   tcp_nopush on;
+   sendfile on;
+   open_file_cache max=200000 inactive=20s;
+   open_file_cache_valid 30s;
+   open_file_cache_min_uses 2;
+   open_file_cache_errors off;
 
-      proxy_http_version 1.1;
+   proxy_http_version 1.1;
    # Force HTTPS connection. This rules is domain agnostic
    if ($scheme != "https") {
       rewrite ^ https://$host$uri permanent;
@@ -42,24 +42,24 @@ server {
       proxy_http_version 1.1;
       proxy_request_buffering off;
 
-            add_header Cache-Control 'no-store, no-cache, max-age=0, no-transform';
+      add_header Cache-Control 'no-store, no-cache, max-age=0, no-transform';
+      add_header Last-Modified $date_gmt;
 
-         add_header Last-Modified $date_gmt;
-                if_modified_since off;
-                expires off;
-                etag off;
+      if_modified_since off;
+      expires off;
+      etag off;
    }
    location = /dev-null {
-   return 200;
+      return 200;
       client_max_body_size 10000M;
    }
    location = /upload {
       client_max_body_size 10000M;
       proxy_pass http://$host:80/dev-null;
    }
-  ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
+   ssl_certificate     /etc/letsencrypt/live/ffmuc.net/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/ffmuc.net/privkey.pem;
-   
+
    access_log /var/log/nginx/{{ domain }}_access.log json_normal;
    error_log  /var/log/nginx/{{ domain }}_error.log;
 }


### PR DESCRIPTION
This PR changes the following things:
- uses the same architecture via traefik
- hardcodes the Host header sent to backend (to not need to extend backend for each new domain)
- uses dynamic domain for redirect to not cause CORS issues when using sites different to speed.ffmuc.net
- whitespacing

Note: this is currently live