### PR TITLE
Cleanup & Updates: apt sources, ffmeet, influx, yanic, graylog-sidecar

### DIFF
--- a/apt/init.sls
+++ b/apt/init.sls
@@ -52,6 +52,9 @@ python3-apt:
 /etc/apt/sources.list.d/universe-factory.list:
   file.absent
 
+/etc/apt/sources.list.d/salt.list:
+  file.absent
+
 /etc/apt/preferences.d/libluajit:
   file.managed:
     - contents: |

--- a/apt/sources.list.Debian.bookworm
+++ b/apt/sources.list.Debian.bookworm
@@ -1,0 +1,17 @@
+#
+# /etc/apt/sources.list (Salt managed)
+#
+
+deb	http://deb.debian.org/debian/ bookworm main non-free contrib
+deb-src	http://deb.debian.org/debian/ bookworm main non-free contrib
+
+deb	http://security.debian.org/debian-security/ bookworm-security main contrib non-free
+deb-src http://security.debian.org/debian-security/ bookworm-security main contrib non-free
+
+# bookworm-updates, previously known as 'volatile'
+deb	http://deb.debian.org/debian/ bookworm-updates main contrib non-free
+deb-src	http://deb.debian.org/debian/ bookworm-updates main contrib non-free
+
+# bookworm-backports, previously on backports.debian.org
+deb	http://deb.debian.org/debian/ bookworm-backports main contrib non-free
+deb-src	http://deb.debian.org/debian/ bookworm-backports main contrib non-free

--- a/apt/sources.list.Debian.bullseye
+++ b/apt/sources.list.Debian.bullseye
@@ -1,0 +1,17 @@
+#
+# /etc/apt/sources.list (Salt managed)
+#
+
+deb	http://deb.debian.org/debian/ bullseye main non-free contrib
+deb-src	http://deb.debian.org/debian/ bullseye main non-free contrib
+
+deb	http://security.debian.org/debian-security/ bullseye-security main contrib non-free
+deb-src http://security.debian.org/debian-security/ bullseye-security main contrib non-free
+
+# bullseye-updates, previously known as 'volatile'
+deb	http://deb.debian.org/debian/ bullseye-updates main contrib non-free
+deb-src	http://deb.debian.org/debian/ bullseye-updates main contrib non-free
+
+# bullseye-backports, previously on backports.debian.org
+deb	http://deb.debian.org/debian/ bullseye-backports main contrib non-free
+deb-src	http://deb.debian.org/debian/ bullseye-backports main contrib non-free

--- a/graylog-sidecar/init.sls
+++ b/graylog-sidecar/init.sls
@@ -3,7 +3,7 @@
 graylog-sidecar-pkg:
   pkg.installed:
     - sources:
-      - graylog-sidecar: https://github.com/Graylog2/collector-sidecar/releases/download/1.2.0/graylog-sidecar_1.2.0-1_armv7.deb
+      - graylog-sidecar: https://github.com/Graylog2/collector-sidecar/releases/download/1.5.1/graylog-sidecar_1.5.1-1_armv7.deb
       - filebeat: https://apt.ffmuc.net/filebeat-oss-8.0.0-SNAPSHOT-armhf.deb
 
 {% else %}{# if grains.osfullname in 'Raspbian' #}

--- a/jitsi/asterisk/init.sls
+++ b/jitsi/asterisk/init.sls
@@ -35,7 +35,7 @@ asterisk_german_sounds_core:
 {% else %}{# ubuntu #}
     - name: /usr/share/asterisk/sounds/de
 {% endif %}
-    - source: https://www.asterisksounds.org/de/download/asterisk-sounds-core-de-sln16.zip
+    - source: https://apt.ffmuc.net/asterisk-sounds-core-de-2.11.19.zip
     - enforce_toplevel: False
     - skip_verify: True
     - user: asterisk
@@ -48,7 +48,7 @@ asterisk_german_sounds_extra:
 {% else %}{# ubuntu #}
     - name: /usr/share/asterisk/sounds/de
 {% endif %}
-    - source: https://www.asterisksounds.org/de/download/asterisk-sounds-extra-de-sln16.zip
+    - source: https://apt.ffmuc.net/asterisk-sounds-extra-de-2.11.19.zip
     - enforce_toplevel: False
     - skip_verify: True
     - user: asterisk

--- a/jitsi/jigasi/config.jinja
+++ b/jitsi/jigasi/config.jinja
@@ -5,7 +5,6 @@ JIGASI_SIPPWD={{ jitsi.jigasi.sip.password }}
 JIGASI_SECRET={{ jitsi.jigasi.xmpp.secret }}
 JIGASI_OPTS="--nocomponent=true"
 JIGASI_HOSTNAME={{ jitsi.public_domain }}
-JIGASI_HOST={{ jitsi.xmpp.server_host }}
 
 # adds java system props that are passed to jigasi (default are for logging config file)
 JAVA_SYS_PROPS="-Djava.util.logging.config.file=/etc/jitsi/jigasi/logging.properties"

--- a/sysctl/global.sls
+++ b/sysctl/global.sls
@@ -81,7 +81,7 @@ net.netfilter.nf_conntrack_max:
   sysctl.present:
     - value: 16777216
     - config: /etc/sysctl.d/10-global.conf
-{% endif %}
+{%- endif %}
 
 # Disable RA
 net.ipv6.conf.default.accept_ra:

--- a/sysctl/init.sls
+++ b/sysctl/init.sls
@@ -2,6 +2,8 @@
 # sysctl
 #
 
+{%- if grains.virtual != 'container' %}
+
 include:
   - sysctl.global
 
@@ -17,9 +19,11 @@ net.ipv6.conf.all.forwarding:
     - value: 1
     - config: /etc/sysctl.d/21-forwarding.conf
 
+{%- endif %}
 
 {# Remove old files #}
 {% for file in ['20-arp_caches.conf', '21-ip_forward.conf', '22-kernel.conf', 'NAT.conf', 'nf-ignore-bridge.conf', 'global.conf', 'router.conf'] %}
 /etc/sysctl.d/{{ file }}:
   file.absent
 {% endfor %}
+

--- a/telegraf/init.sls
+++ b/telegraf/init.sls
@@ -14,7 +14,7 @@ influx-db-repo-key:
 
 influx-db-repo:
   pkgrepo.managed:
-    - name: deb [signed-by=/usr/share/keyrings/influxdb-keyring.gpg] https://repos.influxdata.com/{{ grains.lsb_distrib_id | lower }} stable main
+    - name: deb [signed-by=/usr/share/keyrings/influxdb-keyring.gpg] https://repos.influxdata.com/{{ grains.os | lower }} stable main
     - file: /etc/apt/sources.list.d/influxdb.list
     - clean_file: True
     - require:

--- a/yanic/init.sls
+++ b/yanic/init.sls
@@ -15,7 +15,7 @@
 yanic:
   pkg.installed:
     - sources:
-      - yanic: https://apt.ffmuc.net/yanic_1.5.2-2_amd64.deb
+      - yanic: https://apt.ffmuc.net/yanic_1.8.3-2_amd64.deb
   service.running:
     - enable: True
     - require:


### PR DESCRIPTION
This pull request includes several cleanups and package/configuration updates:

* **APT sources:**

  * Added new `sources.list` files for Debian *bookworm* and *bullseye*
  * Removed obsolete entries (e.g., `salt.list`)

* **ffmeet / jitsi / asterisk:**

  * Switched German Asterisk sound package URLs to local mirror (`apt.ffmuc.net`) as upstream is no more.

* **graylog-sidecar:**

  * Updated version from `1.2.0` to `1.5.1` for armv7

* **telegraf:**

  * Fixed `pkgrepo.managed` to use `grains.os` instead of `grains.lsb_distrib_id` (to support Debian)

* **yanic:**

  * Updated to version `1.8.3-2` from local apt mirror

* **sysctl:**

  * Minor Jinja formatting corrections
  * Conditional handling for containers (skip forwarding setup inside containers), as they do not have their own kernel (e.g. lxc)

* **jigasi:**

  * Removed unused variable `JIGASI_HOST`

---

FYI, already deployed in prod.
