### PR TITLE
Switch over to new mirrors/URLs

### DIFF
--- a/nginx/domains/firmware.ffmuc.net.conf
+++ b/nginx/domains/firmware.ffmuc.net.conf
@@ -105,7 +105,7 @@ server {
 
     # opkg mirror
     location ~^/openwrt/(?<file>.+)$ {
-        return 302 http://ftp.stw-bonn.de/pub/openwrt/$file;
+        return 302 https://mirror.kumi.systems/openwrt/$file;
     }
 
     location ~ /\. {
@@ -114,12 +114,12 @@ server {
 
     # opkg mirror
     location ~^/openwrt/(?<file>.+)$ {
-        return 302 http://ftp.stw-bonn.de/pub/openwrt/$file;
+        return 302 https://mirror.kumi.systems/openwrt/$file;
     }
 
     # lede mirror
     location ~^/lede/(?<file>.+)$ {
-        return 302 http://downloads.lede-project.org/releases/$file;
+        return 302 https://downloads.openwrt.org/releases/$file;
     }
 
     location /wpad.dat {


### PR DESCRIPTION
As the stw-bonn.de mirror is no longer listed on OpenWrt, we should switch to a supported one. I have also updated the lede-project.org URL to OpenWrt, as these are now the same.

Fixes #199 