### PR TITLE
fix: use force-fetch for gluon-firmware-selector

### DIFF
--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -98,6 +98,8 @@ nginx-configtest:
     - rev: main-ffmuc
     - target: /srv/www/firmware.ffmuc.net/.gluon-firmware-selector
     - force_reset: True
+    # force fetching is required as the repo is force-pushed
+    - force_fetch: True
     - require:
       - file: /srv/www/firmware.ffmuc.net
 


### PR DESCRIPTION
This allows us to update the gluon-firmware-selector again:

```
----------
          ID: /srv/www/firmware.ffmuc.net/.gluon-firmware-selector
    Function: git.latest
        Name: https://github.com/freifunkMUC/gluon-firmware-selector.git
      Result: False
     Comment: Fetch failed. Set 'force_fetch' to True to force the fetch if the failure was due to not being able to fast-forward. Output of the fetch command follows:

              From https://github.com/freifunkMUC/gluon-firmware-selector
               ! [rejected]        main-ffmuc -> origin/main-ffmuc  (non-fast-forward)
     Started: 14:24:40.340780
    Duration: 1117.447 ms
     Changes:
----------
          ID: /srv/www/firmware.ffmuc.net/.gluon-firmware-selector/config.js
    Function: file.managed
      Result: False
     Comment: One or more requisite failed: nginx./srv/www/firmware.ffmuc.net/.gluon-firmware-selector
     Started: 14:24:41.459042
    Duration: 0.003 ms
     Changes:
```