### PR TITLE
firmware: override the downloadable firmware

### DIFF
--- a/nginx/files/config.js
+++ b/nginx/files/config.js
@@ -65,9 +65,9 @@ var config = {
     '/gluon-v2023.2.x_v2023.1.x/testing/factory/': 'testing',
     '/gluon-v2023.2.x_v2023.1.x/testing/other/': 'testing',
     '/gluon-v2023.2.x_v2023.1.x/testing/sysupgrade/': 'testing',
-    '/gluon-v2023.2.x_v2023.1.x/stable/factory/': 'stable',
-    '/gluon-v2023.2.x_v2023.1.x/stable/other/': 'stable',
-    '/gluon-v2023.2.x_v2023.1.x/stable/sysupgrade/': 'stable',
+    '/v2025.12.3/stable/factory/': 'stable',
+    '/v2025.12.3/stable/other/': 'stable',
+    '/v2025.12.3/stable/sysupgrade/': 'stable',
 
     // OpenWrt 24.10
     '/gluon-main/experimental/factory/': 'gluon-main',


### PR DESCRIPTION
While we have to deal on how to roll out the fix for #776 without breaking more devices, we want people to only install a firmware version that can be upgrade in the future without problems.

See https://firmware.ffmuc.net/v2025.12.3/