### PR TITLE
feat: use device-picture SVGs in firmware selector

### DIFF
--- a/nginx/files/config.js
+++ b/nginx/files/config.js
@@ -94,7 +94,8 @@ var config = {
   // experimental branches (show a warning for these branches)
   experimental_branches: ['experimental', 'gluon-main', 'gluon-next'],
   // path to preview pictures directory
-  preview_pictures: '/.gluon-firmware-selector/pictures/',
+  preview_pictures: '/device-pictures/pictures-svg/',
+  preview_pictures_ext: '.svg',
   // link to changelog
   changelog: 'https://github.com/freifunkMUC/site-ffm/releases',
   // links for instructions like flashing of certain devices (optional)

--- a/nginx/init.sls
+++ b/nginx/init.sls
@@ -112,6 +112,15 @@ nginx-configtest:
     - require:
       - git: /srv/www/firmware.ffmuc.net/.gluon-firmware-selector
 
+/srv/www/firmware.ffmuc.net/device-pictures:
+  git.latest:
+    - name: https://github.com/freifunk/device-pictures.git
+    - rev: main
+    - target: /srv/www/firmware.ffmuc.net/device-pictures
+    - force_reset: True
+    - require:
+      - file: /srv/www/firmware.ffmuc.net
+
 {% for domain in salt['pillar.get']('netbox:config_context:webserver:domains') %}
 /etc/nginx/sites-enabled/{{ domain }}.conf:
   file.managed:


### PR DESCRIPTION
Marking as draft, as I am unsure about the performance impact of using SVGs. Currently only applied manually.

If SVGs turn out to be too heavy for some low-end devices, we need to add a step to render them to PNGs.