### PR TITLE
Update PowerDNS Recursor to v5.4 release train

### DIFF
--- a/pdns-recursor/init.sls
+++ b/pdns-recursor/init.sls
@@ -12,7 +12,7 @@ pdns-repo-key:
 
 pdns-repo:
   pkgrepo.managed:
-    - name: deb [arch=amd64] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-52 main
+    - name: deb [arch=amd64] http://repo.powerdns.com/{{ grains.lsb_distrib_id | lower }} {{ grains.oscodename }}-rec-54 main
     - file: /etc/apt/sources.list.d/pdns.list
     - clean_file: True
     - require:


### PR DESCRIPTION
As already deployed on gws and webfrontends