### PR TITLE
telegraf: ignore high-cardinality Docker network interfaces

### DIFF
--- a/telegraf/files/telegraf.conf
+++ b/telegraf/files/telegraf.conf
@@ -29,6 +29,8 @@
 [[inputs.interrupts]]
 [[inputs.linux_sysctl_fs]]
 [[inputs.net]]
+  [inputs.net.tagdrop]
+    interface = ["veth*", "br-*[0-9]*"]
 [[inputs.netstat]]
 [[inputs.nstat]]
   proc_net_netstat = "/proc/net/netstat"


### PR DESCRIPTION
Telegraf/InfluxDB is complaining about the high cardinality of the `interface` tag of the `net` measurement again:
```
Failed to write metric (will be dropped: 400 Bad Request): partial write: max-values-per-tag limit exceeded (100000/100000): measurement="net" tag="interface" value="veth4d16407" dropped=26 for database: ffmuc_other for retention policy: autogen
```

This is primarily caused by Docker, creating new `veth` and `br-` interfaces with randomly generated hexadecimal names whenever containers are recreated.

Metrics for these Docker interfaces aren't really useful to us anyway, so let's drop them.
I am using `"veth*", "br-*[0-9]*"` as pattern to drop, which should catch all these Docker interfaces but not include our bridge interfaces on the gateways for example, which don't have any digits in them.