### PR TITLE
nginx/map: reverse-proxy Grafana API same-origin under /grafana/

### DIFF
--- a/nginx/domains/map.ffmuc.net.conf
+++ b/nginx/domains/map.ffmuc.net.conf
@@ -2,7 +2,16 @@ upstream map_data_upstream {
    server gw04.ext.ffmuc.net:443;
 }
 
+# Grafana API backend for the meshviewer's client-side charts, proxied same-origin
+# under /grafana/ below so the browser needs no CORS preflight. Deliberately
+# self-contained (own upstream) so this vhost does not depend on stats.ffmuc.net.conf.
+upstream grafana_api_backend {
+   server metrics.ov.ffmuc.net:3000;
+   keepalive 32;
+}
+
 proxy_cache_path /var/cache/nginx-map levels=1:2 keys_zone=map_cache:10m inactive=120m use_temp_path=off;
+proxy_cache_path /var/cache/nginx-grafana-api levels=1:2 keys_zone=grafana_map_api:64m inactive=10m use_temp_path=off;
 
 server {
    listen {{ sslPort }} ssl;
@@ -39,6 +48,37 @@ server {
       proxy_cache map_cache;
       proxy_cache_valid 200 302 1m;
       proxy_cache_revalidate  on;
+   }
+
+   # Grafana HTTP API, served same-origin for the meshviewer's client-side charts: its
+   # config sets grafana.url = "/grafana", so the browser requests /grafana/api/ds/query
+   # here, and same-origin means no CORS preflight is needed.
+   # The trailing slash on proxy_pass strips the prefix: /grafana/api/ds/query -> /api/ds/query.
+   location /grafana/ {
+      proxy_pass         https://grafana_api_backend/;
+      proxy_redirect     off;
+      proxy_set_header   Host stats.ffmuc.net;
+      proxy_set_header   X-Real-IP $remote_addr;
+      proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header   X-Forwarded-Host $server_name;
+      # reuse upstream connections (enables the keepalive set on the upstream above)
+      proxy_http_version 1.1;
+      proxy_set_header   Connection "";
+
+      # Cache the (POST) data queries so repeated views of a node collapse to a single
+      # InfluxDB query, like the grafana_datasources cache on stats.ffmuc.net. The body is
+      # part of the key and from/to are relative ("now-7d"), so the key is stable per node.
+      # TTL = yanic's collect_interval (1m, see yanic/yanic.conf.tmpl): data gains at most
+      # one point per minute, so 60s adds no perceptible staleness.
+      proxy_cache                   grafana_map_api;
+      proxy_cache_methods           POST;
+      proxy_cache_key               "$request_uri|$request_body";
+      proxy_cache_valid             200 60s;
+      proxy_cache_lock              on;
+      proxy_cache_use_stale         error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_background_update on;
+      proxy_ignore_headers          Cache-Control expires;
+      add_header                    X-Cache-Status $upstream_cache_status;
    }
 
    access_log /var/log/nginx/{{ domain }}_access.log json_normal;


### PR DESCRIPTION
The meshviewer's client-side charts query Grafana's /api/ds/query. Serving that cross-origin from stats.ffmuc.net triggers a CORS preflight that Grafana answers with 404 (no CORS headers), so the charts fail to load. Proxy the Grafana API under map.ffmuc.net/grafana/ so the browser request is same-origin and needs no preflight; the meshviewer config sets grafana.url = "/grafana" to match.

The POST data queries are cached (key includes the request body; the relative from/to keep it stable per node) with a 60s TTL matching yanic's collect_interval, to bound InfluxDB load as the map scales. A self-contained upstream is used so this vhost does not depend on stats.ffmuc.net.conf.