### PR TITLE
backup: replace duplicity by rustic

### DIFF
--- a/duplicity/disable.sls
+++ b/duplicity/disable.sls
@@ -1,0 +1,27 @@
+{%- if 'backup' in salt['pillar.get']('netbox:tag_list', []) -%}
+# runs daily to cleanup duplicity but slowly as rustic backups fill
+backup-script:
+  file.managed:
+    - name: /usr/local/sbin/backup.sh
+    - contents: |
+        #!/usr/bin/env bash
+
+        APPLICATION_KEY="{{ salt['config.get']('netbox:config_context:backblaze:application_key')  }}"
+        KEYID="{{ salt['config.get']('netbox:config_context:backblaze:keyid') }}"
+        export PASSPHRASE="{{ salt['config.get']('netbox:config_context:backup:password') }}"
+        BUCKET="FFMUC-Backups"
+
+        duplicity remove-older-than 14D --force b2://$KEYID:$APPLICATION_KEY@$BUCKET/{{ grains.id }}
+        unset PASSPHRASE
+    - mode: "0750"
+    - template: jinja
+
+ffmuc-backup-timer-disable:
+  #service.dead:
+  #  - name: ffmuc-backup.timer
+  #  - enable: false
+  service.running:
+    - name: ffmuc-backup.timer
+    - enable: true
+
+{% endif %}{# if backup in tags #}

--- a/duplicity/remove.sls
+++ b/duplicity/remove.sls
@@ -1,0 +1,27 @@
+
+duplicity:
+  pkg.removed
+
+remove_duplicity_files:
+  file.absent:
+    - names:
+        - /usr/share/keyrings/duplicity-team-keyring.gpg
+        - /etc/apt/sources.list.d/duplicity.list
+        - /usr/local/sbin/backup.sh
+        - /etc/systemd/system/ffmuc-backup.service
+        - /etc/systemd/system/ffmuc-backup.timer
+    - require:
+      - service: ffmuc-backup-timer-disable
+      - pkg: duplicity
+
+systemd-reload-ffmuc-backup:
+  cmd.run:
+    - name: systemctl --system daemon-reload
+    - onchanges:
+      - file: remove_duplicity_files
+
+
+ffmuc-backup-timer-disable:
+  service.dead:
+    - name: ffmuc-backup.timer
+    - enable: false

--- a/rustic/files/ffmuc-rustic-backup-cleaner.service
+++ b/rustic/files/ffmuc-rustic-backup-cleaner.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=FFMuc rustic Backup Cleaner
+
+[Service]
+Nice=19
+IOSchedulingClass=idle
+ExecStart=/usr/local/bin/rustic prune

--- a/rustic/files/ffmuc-rustic-backup-cleaner.timer
+++ b/rustic/files/ffmuc-rustic-backup-cleaner.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Cleans FFmuc-rustic-backup every month at 5 am
+
+[Timer]
+OnCalendar=*-*-01 5:00:00
+RandomizedDelaySec=1h
+Unit=ffmuc-rustic-backup-cleaner.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/rustic/files/ffmuc-rustic-backup.service
+++ b/rustic/files/ffmuc-rustic-backup.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=FFMuc rustic Backup
+
+[Service]
+Nice=19
+IOSchedulingClass=idle
+ExecStart=/bin/bash /usr/local/sbin/rustic-backup.sh

--- a/rustic/files/ffmuc-rustic-backup.timer
+++ b/rustic/files/ffmuc-rustic-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Runs FFmuc-rustic-backup every day
+
+[Timer]
+OnCalendar=*-*-* 3:00:00
+RandomizedDelaySec=3600
+Unit=ffmuc-rustic-backup.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/rustic/files/rustic-backup.sh.j2
+++ b/rustic/files/rustic-backup.sh.j2
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# rustic is configured via rustic.toml
+
+rustic backup
+
+rustic forget

--- a/rustic/files/rustic.toml.j2
+++ b/rustic/files/rustic.toml.j2
@@ -1,0 +1,52 @@
+# rustic config file to use B2 storage via Apache OpenDAL
+[repository]
+repository = "opendal:b2" # just specify the opendal service here
+password = "{{ salt['config.get']('netbox:config_context:backup:password') }}"
+cache-dir = "/var/cache/rustic"
+
+# B2 specific options
+[repository.options]
+# Here, we give the required b2 options, see https://opendal.apache.org/docs/rust/opendal/services/struct.B2.html
+application_key_id = "{{ salt['config.get']('netbox:config_context:backblaze:keyid') }}"
+application_key = "{{ salt['config.get']('netbox:config_context:backblaze:application_key')  }}"
+bucket = "{{ salt['config.get']('netbox:config_context:backup:bucket:name', "") }}"
+bucket_id = "{{ salt['config.get']('netbox:config_context:backup:bucket:id', "") }}"
+root = "/restic-repo" # Set a repository root directory if not using the root directory of the bucket
+
+[snapshot-filter]
+filter-hosts = ["{{ grains.id }}"]
+
+[backup]
+host = "{{ grains.id }}"
+exclude-if-present = [".nobackup", "CACHEDIR.TAG"] # Default: not set
+{#- mastodon-data is on external filesystem in /srv/docker. if this is true it wont be backed up #}
+one-file-system = false
+
+# Note that if you call "rustic backup" without any source, all sources from this config
+# file will be processed.
+[[backup.snapshots]]
+sources = [{% for backup_dir in salt['config.get']('netbox:config_context:backup:directories') %}
+    "{{ backup_dir }}",
+{%- endfor %}
+]
+{%- for name, command in salt['config.get']('netbox:config_context:backup:stdin_commands', {}).items() %}
+
+[[backup.snapshots]]
+name = "stdin-{{ name }}"
+sources = ["-"]
+stdin-command = "{{ command }}"
+as-path = "{{ name }}"
+{%- endfor %}
+
+[forget]
+prune = false # done centrally by host tagged with 'backup-cleaner'
+filter-hosts = ["{{ grains.id }}"]
+
+keep-last = 7
+keep-hourly = 5
+keep-daily = 14
+keep-weekly = 4
+keep-monthly = 0
+keep-quarter-yearly = 0
+keep-half-yearly = 0
+keep-yearly = 0

--- a/rustic/init.sls
+++ b/rustic/init.sls
@@ -1,0 +1,99 @@
+{%- if 'backup' in salt['pillar.get']('netbox:tag_list', []) -%}
+
+{% set rustic_version = "v0.11.3" %}
+install_rustic:
+  #archive.extracted:
+  #  - name: /tmp/rustic
+  #  - source: https://github.com/rustic-rs/rustic/releases/download/{{ rustic_version }}/rustic-{{ rustic_version }}-x86_64-unknown-linux-musl.tar.gz
+  #  - source_hash: "https://github.com/rustic-rs/rustic/releases/download/{{ rustic_version }}/rustic-{{ rustic_version }}-x86_64-unknown-linux-musl.tar.gz.sha256"
+  #  - cleanup: true
+  #  - creates: /usr/local/bin/rustic
+  #  - enforce_toplevel: false
+  #  - keep_source: false
+  #cmd.run:
+  #  - name: mv /tmp/rustic/rustic /usr/local/bin/rustic && chmod +x /usr/local/bin/rustic
+  #  - unless: test -f /usr/local/bin/rustic
+  file.managed:
+    - name: /usr/local/bin/rustic
+    - source: salt://rustic/files/rustic
+    - mode: "0755"
+
+backup-config:
+  file.managed:
+    - name: /root/.config/rustic/rustic.toml
+    - source: salt://rustic/files/rustic.toml.j2
+    - makedirs: True
+    - mode: "0600"
+    - template: jinja
+    - require:
+      #- archive: install_rustic
+      #- cmd: install_rustic
+      - file: install_rustic
+
+backup-script:
+  file.managed:
+    - name: /usr/local/sbin/rustic-backup.sh
+    - source: salt://rustic/files/rustic-backup.sh.j2
+    - mode: "0750"
+    - template: jinja
+    - require:
+      - file: backup-config
+
+/etc/systemd/system/ffmuc-rustic-backup.service:
+  file.managed:
+    - source: salt://rustic/files/ffmuc-rustic-backup.service
+    - require:
+      - file: backup-script
+
+/etc/systemd/system/ffmuc-rustic-backup.timer:
+  file.managed:
+    - source: salt://rustic/files/ffmuc-rustic-backup.timer
+    - require:
+      - file: backup-script
+
+systemd-reload-ffmuc-backup:
+  cmd.run:
+    - name: systemctl --system daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/ffmuc-rustic-backup.service
+      - file: /etc/systemd/system/ffmuc-rustic-backup.timer
+    - require:
+      - file: /etc/systemd/system/ffmuc-rustic-backup.service
+      - file: /etc/systemd/system/ffmuc-rustic-backup.timer
+
+ffmuc-backup-timer-enable:
+  service.running:
+    - name: ffmuc-rustic-backup.timer
+    - enable: true
+    - require:
+      - file: /etc/systemd/system/ffmuc-rustic-backup.timer
+    - full_restart: True
+
+{% if 'backup-cleaner' in salt['pillar.get']('netbox:tag_list', []) -%}
+
+/etc/systemd/system/ffmuc-rustic-backup-cleaner.service:
+  file.managed:
+    - source: salt://rustic/files/ffmuc-rustic-backup-cleaner.service
+    - require:
+      - file: backup-config
+    - require_in:
+      - cmd: systemd-reload-ffmuc-backup
+
+/etc/systemd/system/ffmuc-rustic-backup-cleaner.timer:
+  file.managed:
+    - source: salt://rustic/files/ffmuc-rustic-backup-cleaner.timer
+    - require:
+      - file: backup-config
+    - require_in:
+      - cmd: systemd-reload-ffmuc-backup
+
+ffmuc-backup-cleaner-timer-enable:
+  service.running:
+    - name: ffmuc-rustic-backup-cleaner.timer
+    - enable: true
+    - require:
+      - file: /etc/systemd/system/ffmuc-rustic-backup-cleaner.timer
+    - full_restart: True
+
+{% endif %}{# if backup_cleaner in tags #}
+{% endif %}{# if backup in tags #}

--- a/rustic/remove.sls
+++ b/rustic/remove.sls
@@ -1,0 +1,35 @@
+
+
+/usr/local/bin/rustic:
+  file.absent
+
+/root/.config/rustic/rustic.toml:
+  file.absent
+
+/usr/local/sbin/rustic-backup.sh:
+  file.absent
+
+ffmuc-backup-timer:
+  service.dead:
+    - name: ffmuc-rustic-backup.timer
+    - enable: false
+
+/etc/systemd/system/ffmuc-rustic-backup.service:
+  file.absent:
+    - require:
+      - service: ffmuc-backup-timer
+
+/etc/systemd/system/ffmuc-rustic-backup.timer:
+  file.absent:
+    - require:
+      - service: ffmuc-backup-timer
+
+systemd-reload-ffmuc-backup:
+  cmd.run:
+    - name: systemctl --system daemon-reload
+    - onchanges:
+      - file: /etc/systemd/system/ffmuc-rustic-backup.service
+      - file: /etc/systemd/system/ffmuc-rustic-backup.timer
+    - require:
+      - file: /etc/systemd/system/ffmuc-rustic-backup.service
+      - file: /etc/systemd/system/ffmuc-rustic-backup.timer

--- a/top.sls
+++ b/top.sls
@@ -25,7 +25,7 @@ base:
     - certs
     - docker
     - dphys-swapfile
-    - duplicity
+    - rustic
     - grafana
     - icinga2
     - influxdb


### PR DESCRIPTION
duplicity is an aged backup solution.
rustic offers better 
- compression
- deduplication
- backup speed (on docker06 from ~13-18 hours for full backup and ~2-6 hours for incremental backup down to ~1h every time with ~350GB of backed up data)

in terms of restic vs rustic:
rustic implements a config file so running backup tasks interactively on hosts is way easier. Using the config file allows strict scoping by host (without changing the config you cannot access backups from other hosts) and reduces env/cli parameters when running simple snapshot listing or restore. Even an intermediate backup (e.g. before changing something) just takes a few minutes even on big datasets which might help running a quick backup before maintenance.